### PR TITLE
Only overwrite config if runmode==init or config doesn't exist

### DIFF
--- a/renee
+++ b/renee
@@ -636,6 +636,32 @@ def get_repo_git_commit_hash(repo_path):
     return githash
 
 
+def scontrol_show():
+    """ Run scontrol show config and parse the output as a dictionary
+    @return scontrol_dict <dict>:
+    """
+    scontrol_dict = dict()
+    scontrol_out = subprocess.run(
+        "scontrol show config", shell=True, capture_output=True, text=True
+    ).stdout
+    if len(scontrol_out) > 0:
+        for line in scontrol_out.split("\n"):
+            line_split = line.split("=")
+            if len(line_split) > 1:
+                scontrol_dict[line_split[0].strip()] = line_split[1].strip()
+    return scontrol_dict
+
+
+def get_hpcname():
+    """ Get the HPC name (biowulf, frce, or an empty string)
+    @return hpcname <str>
+    """
+    scontrol_out = scontrol_show()
+    hpc = scontrol_out["ClusterName"] if "ClusterName" in scontrol_out.keys() else ''
+    if hpc == 'fnlcr':
+        hpc = 'frce'
+    return hpc
+
 def setup(sub_args, ifiles, repo_path, output_path):
     """Setup the pipeline for execution and creates config file from templates
     @param sub_args <parser.parse_args() object>:
@@ -651,18 +677,13 @@ def setup(sub_args, ifiles, repo_path, output_path):
     # Resolves PATH to template for genomic reference files to select from a
     # bundled reference genome or a user generated reference genome built via
     # renee build subcommand
-    x = subprocess.run(
-        "scontrol show config", shell=True, capture_output=True, text=True
-    )
-    hpcname = ""
-    if "biowulf" in x.stdout:
-        hpcname = "biowulf"
+    hpcname = get_hpcname()
+    if hpcname == "biowulf":
         print("Thank you for running RENEE on BIOWULF!")
         genome_config = os.path.join(
             output_path, "config", "genomes", hpcname, sub_args.genome + ".json"
         )
-    elif "fsitgl" in x.stdout:
-        hpcname = "frce"
+    elif hpcname == "frce":
         print("Thank you for running RENEE on FRCE!")
         genome_config = os.path.join(
             output_path, "config", "genomes", hpcname, sub_args.genome + ".json"
@@ -747,7 +768,7 @@ def setup(sub_args, ifiles, repo_path, output_path):
         json.dump(config, fh, indent=4, sort_keys=True)
     print("Done!")
 
-    return config, hpcname
+    return config
 
 
 def dryrun(
@@ -1039,7 +1060,8 @@ def run(sub_args):
 
     # Step pipeline for execution, create config.json config file from templates
     # hpcname is either biowulf or frce or blank
-    config, hpcname = setup(
+    hpcname = get_hpcname()
+    config = setup(
         sub_args, ifiles=input_files, repo_path=git_repo, output_path=sub_args.output
     )
 

--- a/renee
+++ b/renee
@@ -1057,7 +1057,7 @@ def run(sub_args):
 
     # hpcname is either biowulf, frce, or blank
     hpcname = get_hpcname()
-    if sub_args.runmode == 'init':
+    if sub_args.runmode == 'init' or not os.path.exists(os.path.join(sub_args.output, 'config.json')):
         # Initialize working directory, copy over required pipeline resources
         input_files = initialize(sub_args, repo_path=git_repo, output_path=sub_args.output)
 
@@ -1820,7 +1820,7 @@ def parsed_arguments(name, description):
     subparser_run.add_argument('--runmode',
         # Determines how to run the pipeline: init, run
         # TODO: this API is different from XAVIER & CARLISLE, which have a --runmode=dryrun option instead of a --dry-run flag.
-        required = True,
+        required = False,
         default = 'run',
         choices = ['init','run'],
         type = str,

--- a/renee
+++ b/renee
@@ -1055,15 +1055,21 @@ def run(sub_args):
     # Get PATH to RENEE git repository for copying over pipeline resources
     git_repo = os.path.dirname(os.path.abspath(__file__))
 
-    # Initialize working directory, copy over required pipeline resources
-    input_files = initialize(sub_args, repo_path=git_repo, output_path=sub_args.output)
-
-    # Step pipeline for execution, create config.json config file from templates
-    # hpcname is either biowulf or frce or blank
+    # hpcname is either biowulf, frce, or blank
     hpcname = get_hpcname()
-    config = setup(
-        sub_args, ifiles=input_files, repo_path=git_repo, output_path=sub_args.output
-    )
+    if sub_args.runmode == 'init':
+        # Initialize working directory, copy over required pipeline resources
+        input_files = initialize(sub_args, repo_path=git_repo, output_path=sub_args.output)
+
+        # Step pipeline for execution, create config.json config file from templates
+        config = setup(
+            sub_args, ifiles=input_files, repo_path=git_repo, output_path=sub_args.output
+        )
+    # load config from existing file
+    else:
+        with open(os.path.join(sub_args.output, "config.json"), "r") as config_file:
+            config = json.load(config)
+        
 
     # Optional Step: Dry-run pipeline
     if sub_args.dry_run:
@@ -1811,7 +1817,16 @@ def parsed_arguments(name, description):
         default=False,
         help=argparse.SUPPRESS,
     )
-
+    subparser_run.add_argument('--runmode',
+        # Determines how to run the pipeline: init, run
+        # TODO: this API is different from XAVIER & CARLISLE, which have a --runmode=dryrun option instead of a --dry-run flag.
+        required = True,
+        default = 'run',
+        choices = ['init','run'],
+        type = str,
+        help = argparse.SUPPRESS
+    )
+    
     # Execution Method, run locally
     # on a compute node or submit to
     # a supported job scheduler, etc.


### PR DESCRIPTION
- Added `--runmode` CLI option
  - Options: run, init. Default: run.  
  - Note that RENEE's CLI is slightly different from XAVIER & CARLISLE. Eventually we may want to try to unify their interfaces.
- Only run `setup()` and `initialize()` if runmode is 'init' or the config file doesn't exist.
- Created separate functions to run scontrol and get the HPC name. 