### PR TITLE
fix bugs in single-end rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Version Notes
+## development version
+
+- Fix bugs that prevented single-end data from running through the pipeline. (#58, @kelly-sovacool)
 
 ## v2.5
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -173,8 +173,8 @@ elif not paired_end:
             # FastQ Screen
             expand(join(workpath,"FQscreen","{name}.R1.trim_screen.txt"),name=samples),
             expand(join(workpath,"FQscreen","{name}.R1.trim_screen.png"),name=samples),
-            expand(join(workpath,"FQscreen2","{name}.R1.trim_screen.txt"),name=samples),
-            expand(join(workpath,"FQscreen2","{name}.R1.trim_screen.png"),name=samples),
+            expand(join(workpath,"FQscreen2","{name}.R1_2.trim_screen.txt"),name=samples),
+            expand(join(workpath,"FQscreen2","{name}.R1_2.trim_screen.png"),name=samples),
 
             # Kraken + Krona
             expand(join(workpath,kraken_dir,"{name}.trim.kraken_bacteria.taxa.txt"),name=samples),

--- a/workflow/rules/single-end.smk
+++ b/workflow/rules/single-end.smk
@@ -742,7 +742,7 @@ rule rnaseq_multiqc:
         expand(join(workpath,rseqc_dir,"{name}.Rdist.info"),name=samples),
         expand(join(workpath,rseqc_dir,"{name}.star_rg_added.sorted.dmark.summary.txt"),name=samples),
         expand(join(workpath,"rawQC","{name}.fastq.info.txt"),name=samples),
-        expand(join(workpath,kraken_dir,"{name}.trim.kraken_bacteria.taxa.txt"),name=sample),
+        expand(join(workpath,kraken_dir,"{name}.trim.kraken_bacteria.taxa.txt"),name=samples),
         fqinfo=expand(join(workpath,"rawQC","{name}.fastq.info.txt"),name=samples),
         tins=expand(join(workpath,rseqc_dir,"{name}.star_rg_added.sorted.dmark.summary.txt"),name=samples)
     output:


### PR DESCRIPTION
Bug fixes for single-end data.

Tested with:

```sh
/data/CCBR_Pipeliner/Pipelines/RENEE/develop/renee run \
    --input /data/CCBR_Pipeliner/Pipelines/RENEE/develop/.tests/*.R1.fastq.gz \
    --output /data/sovacoolkl/renee_test_se \
    --genome hg38_30 --mode slurm --sif-cache /data/CCBR_Pipeliner/SIFS
```

Completed successfully on biowulf.

## Issues

- fixes #56
- fixes #59 