### PR TITLE
chore: create PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Changes
+
+<!--
+Provide a summary of what is included in this Pull Request (PR).
+-->
+
+## Issues
+
+<!--
+Reference any issues related to this PR.
+If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
+when referring to the issue.
+-->
+
+<!--
+**Reviewers**: Use the @ feature to mention anyone responsible for reviewing/completing this request.
+-->
+
+## PR Checklist
+
+(~Strikethrough~ any points that are not applicable.)
+
+- [ ] This comment contains a description of changes with justifications, with any relevant issues linked.
+- [ ] Update docs if there are any API changes.
+- [ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/


### PR DESCRIPTION
Includes a checklist to ensure PRs include a descriptive comment, update the docs if there are API changes, and update the changelog if there are any user-facing changes.