### PR TITLE
ci: update sync-fork action permissions

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -2,27 +2,31 @@ name: Sync Fork
 
 on:
   schedule:
-    - cron: '0 0 * * *' # once every day
+    - cron: "39 11 * * *" # once every day
   workflow_dispatch: # on button click
   push:
     paths:
       - .github/workflows/sync-fork.yml
 
+permissions:
+  contents: write
+
 env:
   GH_TOKEN: ${{ github.token }}
-  FORK_OWNER: NCIPangea
   UPSTREAM_OWNER: CCBR
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        FORK_OWNER: [NCIPangea]
     steps:
-      - name: get repo name
-        # required for actions scheduled via cron, as github.event.repository.name won't work
-        run: |
-            echo "REPO=$(basename ${{ github.repository }})" >> $GITHUB_ENV
       - name: sync fork
         # only run this action from the forked repo
-        if: ${{ github.repository_owner == env.FORK_OWNER }}
+        if: ${{ github.repository_owner == matrix.FORK_OWNER }}
         run: |
+          # required for actions scheduled via cron, as github.event.repository.name won't work
+          REPO=$(basename ${{ github.repository }})
+          # sync the fork from upstream
           gh repo sync ${{ github.repository }} --source $UPSTREAM_OWNER/$REPO --force


### PR DESCRIPTION
and use matrix strategy to allow expansion to other fork owners.

I set the cron schedule to run at 11:39 so we can see if it will work for NCIPangea/RENEE.