### PR TITLE
chore: add pre-commit hook to validate JSON files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,8 @@ repos:
       - id: check-added-large-files
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-json
+      - id: check-yaml
   # spell check
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-json
-      - id: check-yaml
   # spell check
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4


### PR DESCRIPTION
## Changes

Uses the built-in `check-json` hook to validate JSON files. It will catch errors such as missing commas, mismatched curly braces, etc.

## Issues

Resolves #75 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~ This PR does not contain user-facing changes.
