### PR TITLE
ci: only run labels action when issue is opened

### DIFF
--- a/.github/workflows/auto_add_reponame_labels.yml
+++ b/.github/workflows/auto_add_reponame_labels.yml
@@ -2,7 +2,11 @@ name: Auto add reponame as label to all issues and PRs
 
 on:
   issues:
+    types:
+      - opened
   pull_request:
+    types:
+      - opened
 
 jobs:
   add_label:


### PR DESCRIPTION
## Changes

Prevents the action from running every time there's any activity on an issue or PR.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
