### PR TITLE
ci: use semi-automated release & post-release actions

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -8,9 +8,6 @@ on:
         required: false
         type: string
         default: ""
-  push:
-    branches:
-      - release-draft
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -132,7 +132,8 @@ jobs:
             --draft \
             --notes-file .github/latest-release.md \
             --target ${{ env.COMMIT_HASH }} \
-            --title "${{ github.event.repository.name }} ${{ env.NEXT_STRICT }}"
+            --title "${{ github.event.repository.name }} ${{ env.NEXT_STRICT }}" \
+            --reviewer ${{ github.event.release.author.login }}
 
       - name: Next steps
         run: |

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,143 @@
+name: draft-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: Semantic version tag for next release. If not provided, it will be determined based on conventional commit history.
+        required: false
+        type: string
+        default: ""
+  push:
+    branches:
+      - release-draft
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  BRANCH: release-draft
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required to include tags
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - run: pip install cffconvert>=2.0.0 pyyaml
+
+      - name: Get Date
+        run: |
+          echo "DATE=$(date +"%Y-%m-%d")" >> "$GITHUB_ENV"
+
+      - name: Get current and next versions
+        id: semver
+        uses: ietf-tools/semver-action@v1
+        with:
+          token: ${{ github.token }}
+          branch: ${{ github.ref_name }}
+
+      - name: Set version variables
+        shell: python {0}
+        run: |
+          import os
+          import re
+          import warnings
+
+          convco_version = "${{ steps.semver.outputs.next }}"
+          if "${{ github.event_name }}" == 'workflow_dispatch' and "${{ github.event.inputs.version_tag }}":
+            next_version = "${{ github.event.inputs.version_tag }}"
+            if next_version != convco_version:
+              warnings.warn(f"Manual version ({next_version}) not equal to version determined by conventional commit history ({convco_version})")
+          else:
+            next_version = convco_version
+
+          with open(os.getenv("GITHUB_ENV"), 'a') as out_env:
+            out_env.write(f"NEXT_VERSION={next_version}\n")
+            out_env.write(f"NEXT_STRICT={next_version.strip('v')}\n")
+          current_version = "${{ steps.semver.outputs.current }}"
+
+          # assert semantic version pattern
+          semver_pattern = 'v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?'
+          next_semver = re.match(semver_pattern, next_version)
+          if not next_semver:
+            raise ValueError(f"Tag {next_version} does not match semantic versioning guidelines")
+
+          # assert next version is only 1 greater than current
+          current_semver = re.match(semver_pattern, current_version)
+          groups = ['major', 'minor', 'patch']
+          greater = sum([next_semver.group(grp) > current_semver.group(grp) for grp in groups])
+          equal = sum([next_semver.group(grp) == current_semver.group(grp) for grp in groups])
+          if not (greater == 1 and equal == 2):
+            raise ValueError(f"Next version must only increment one number at a time. Current version: {current_version}. Proposed next version: {next_version}")
+
+      - name: Get release notes, update changelog & version file
+        shell: python {0}
+        run: |
+          import os
+          latest_version = "${{ steps.semver.outputs.current }}".strip('v')
+          next_version = "${{ env.NEXT_STRICT }}"
+
+          changelog_lines = list()
+          next_release_lines = list()
+          for_next = True
+          with open("CHANGELOG.md", "r") as infile:
+            for line in infile:
+              if line.startswith('#') and 'development version' in line:
+                line = line.replace('development version', next_version)
+              elif latest_version in line:
+                for_next = False
+
+              changelog_lines.append(line)
+              if for_next:
+                next_release_lines.append(line)
+
+          with open(".github/latest-release.md", "w") as outfile:
+            outfile.writelines(next_release_lines)
+          with open('CHANGELOG.md', 'w') as outfile:
+            outfile.writelines(changelog_lines)
+          with open("VERSION", "w") as outfile:
+            outfile.write(f"{next_version}\n")
+
+      - name: Update citation
+        shell: python {0}
+        run: |
+          from cffconvert.cli.create_citation import create_citation
+          from cffconvert.cli.validate_or_write_output import validate_or_write_output
+          import yaml
+
+          citation = create_citation('CITATION.cff', None)
+          citation._implementation.cffobj['version'] = "${{ env.NEXT_VERSION }}"
+          citation._implementation.cffobj['date-released'] = "${{ env.DATE }}"
+          with open('CITATION.cff', 'w') as outfile:
+            outfile.write(yaml.dump(citation._implementation.cffobj, sort_keys=False))
+
+      - name: Commit & push to branch
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git push origin --delete ${{ env.BRANCH }} || echo "No ${{ env.BRANCH }} branch to delete"
+          git switch -c ${{ env.BRANCH }} || git switch ${{ env.BRANCH }}
+          git merge --ff-only ${{ github.ref_name }}
+
+          git add CITATION.cff CHANGELOG.md VERSION
+          git commit -m 'chore: prepare release ${{ env.NEXT_VERSION }}'
+          git push --set-upstream origin ${{ env.BRANCH }}
+
+          echo "COMMIT_HASH=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Tag & draft release
+        run: |
+          gh release create ${{ env.NEXT_VERSION }} \
+            --draft \
+            --notes-file .github/latest-release.md \
+            --target ${{ env.COMMIT_HASH }} \
+            --title "${{ github.event.repository.name }} ${{ env.NEXT_STRICT }}"
+
+      - name: Next steps
+        run: |
+          echo "Next steps: Take a look at the changes in the ${{ env.BRANCH }} branch and the release notes on the web. If everything is correct, publish the release. Otherwise, delete the release draft and cut the release manually."

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -88,7 +88,7 @@ jobs:
                 for_next = False
 
               changelog_lines.append(line)
-              if for_next:
+              if for_next and next_version not in line:
                 next_release_lines.append(line)
 
           with open(".github/latest-release.md", "w") as outfile:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -70,8 +70,7 @@ jobs:
           current_semver = re.match(semver_pattern, current_version)
           groups = ['major', 'minor', 'patch']
           greater = sum([next_semver.group(grp) > current_semver.group(grp) for grp in groups])
-          equal = sum([next_semver.group(grp) == current_semver.group(grp) for grp in groups])
-          if not (greater == 1 and equal == 2):
+          if not (greater == 1):
             raise ValueError(f"Next version must only increment one number at a time. Current version: {current_version}. Proposed next version: {next_version}")
 
       - name: Get release notes, update changelog & version file

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,50 @@
+name: post-release
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  BRANCH: release/${{ github.ref_name }}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure git
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git push origin --delete ${{ env.BRANCH }} || echo "No ${{ env.BRANCH }} branch to delete"
+          git switch -c ${{ env.BRANCH }}
+      - name: Bump changelog & version
+        shell: python {0}
+        run: |
+          with open("CHANGELOG.md", "r") as infile:
+            lines = infile.readlines()
+          lines.insert(0, "## ${{ github.event.repository.name }} development version\n\n")
+          with open("CHANGELOG.md", "w") as outfile:
+            outfile.writelines(lines)
+
+          with open('VERSION', 'r') as infile:
+            version = infile.read().strip()
+          with open('VERSION', 'w') as outfile:
+            outfile.write(f"{version}-dev\n")
+
+      - name: Open pull request
+        run: |
+          git add CHANGELOG.md VERSION
+          git commit -m "chore: bump changelog & version after release of ${{ github.ref_name }}"
+          git push --set-upstream origin ${{ env.BRANCH }}
+
+          gh pr create \
+            --fill-first
+
+      - name: Clean up release-draft branch
+        run: |
+          git push origin --delete release-draft || echo "No release-draft branch to delete"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,36 @@
-## development version
+## RENEE development version
+
+- Create a citation file to describe how to cite RENEE. (#86, @kelly-sovacool)
 - Fix: set HPC-specific fastq screen config and kraken DB paths for Biowulf and FRCE. (#78, @kelly-sovacool)
-  - Previously, FRCE users were required to set `--shared-resources`, 
-    which were kept in a location on FRCE not under version control. 
-    This change brings the paths under version control so they're easier to recover if deleted. 
+  - Previously, FRCE users were required to set `--shared-resources`,
+    which were kept in a location on FRCE not under version control.
+    This change brings the paths under version control so they're easier to recover if deleted.
 - Fix permissions to allow read/write access to the scripts dir which caused rNA report to fail (#91, @slsevilla)
 - Fix RSEM reference and rRNA interval list paths in FRCE-specific config files (#85, @kelly-sovacool & @slsevilla)
-- Create a citation file to describe how to cite RENEE. (#86, @kelly-sovacool)
 - Fix bug which caused incorrect genome annotation JSON files to be used (#87, @kelly-sovacool)
 
+## RENEE 2.5.10
 
-## v2.5.10
+- Fix a bug that caused slurm jobs to fail. (#74, @kopardev)
 
-- Fix a bug that caused slurm jobs to fail (#74, @kopardev)
-
-## v2.5.9
+## RENEE 2.5.9
 
 - Fix bugs that prevented single-end data from running through the pipeline. (#58, @kelly-sovacool)
 - Increase wall time for kraken and bbmerge rules. (#68, @slsevilla)
 
-## v2.5
+## RENEE 2.5
 
 - `SLURM_SUBMIT_HOST` adding to get hostname correctly on compute nodes.
 - `config.json` is only created when runmode==init and is no longer recreated or overwritten when runmode==run or when resuming a previously unsuccessful run.
 - prebuilt*list, a list of `<genome>*<gencode_annotation>` combos is auto-populated by glob-ing for relevant JSON files in the RENEEDIR/resources folder.
 
-## v2.4
+## RENEE 2.4
 
 - "pipelinehome" added to `config.json` in output folder.
 - `cluster.json` optimized.
 - `"\.R1$", "\.R2$"` added to `workflow/scripts/pyparser.py`. This helps FQscreen2 output correctly collected in the `multiqc_matrix.tsv` which is required for rNA report HTML.
 
-## v2.3
+## RENEE 2.3
 
 - `runner` orchestration script updated for:
   - `--wait` and `--create-nidap-folder` options added for _frce_. Also work on _biowulf_. These are required when running **RENEE** with NIDAP API call.
@@ -40,18 +40,18 @@
 - "\_2" suffix added to "FQscreen2" files to distinguish them from "FQscreen" files. Now two separate fqscreen plots per sample are reported in the multiqc report.
 - Custom Kraken2 database created and used. The "Standard" Kraken2 database was missing mouse genome.. hence it was added.
 
-## v2.2
+## RENEE v2.2
 
 - `spooker` utility added to `onsuccess` and `onerror` blocks in `Snakefile`. Only works for _biowulf_.
 
-## v2.1
+## RENEE 2.1
 
 - `spooker` utility added to track userdata on _biowulf_.
 - CLI support for _frce_ implemented.
 - resource jsons split into 2 folders _biowulf_ and _frce_ to store HPC-specific JSONs.
 - resource bundles created on both, _biowulf_ and _frce_, for 4 **hg38** and 3 **mm10** genome+annotation combinations.
 
-## v2.0
+## RENEE 2.0
 
 - new name **RENEE**
 - `redirect` wrapper script added.


### PR DESCRIPTION
## Changes

- The **draft-release** action is run on manual dispatch, using the latest commit from whichever branch you select. It detects the next version, updates the changelog, citation, and version files, and creates a draft release. You can then view the proposed tag, make any edits, and manually publish the release.
- The **post-release** action runs automatically after you publish a release. It updates the changelog and version files for the development version, creates a branch `release-${tag}` (with the version tag),  and opens a pull request with these changes. It also deletes the `release-draft` branch during cleanup.

### Requirements

- The files `CHANGELOG.md`, `VERSION`, and `CITATION.cff` must exist in the top level of the repo.
- `CHANGELOG.md` must contain a header containing the string 'development version', and this should be the first header in the file. It's crucial to update the changelog with every PR that contains user-facing changes as these become the release notes for the next version.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~ [**these changes are not user-facing**]
