### PR TITLE
fix: set default tmp dir for biowulf & frce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix permissions to allow read/write access to the scripts dir which caused rNA report to fail (#91, @slsevilla)
 - Fix RSEM reference and rRNA interval list paths in FRCE-specific config files (#85, @kelly-sovacool & @slsevilla)
 - Fix bug which caused incorrect genome annotation JSON files to be used (#87, @kelly-sovacool)
+- Set default temporary directory depending on HPC platform. (#98, @kelly-sovacool)
 
 ## RENEE 2.5.10
 

--- a/docs/RNA-seq/build.md
+++ b/docs/RNA-seq/build.md
@@ -154,7 +154,7 @@ Each of the following arguments are optional and do not need to be provided. If 
 > _type: path_  
 > _default: `/lscratch/$SLURM_JOBID`_
 >
-> Path on the file system for writing temporary output files. By default, the temporary directory is set to '/lscratch/$SLURM_JOBID' on NIH's Biowulf cluster and 'outdir' on the FRCE cluster. However, if you are running the pipeline on another cluster, this option will need to be specified. Ideally, this path should point to a dedicated location on the filesystem for writing tmp files. On many systems, this location is set to somewhere in /scratch. If you need to inject avariable into this string that should NOT be expanded,please quote this options value in single quotes.
+> Path on the file system for writing temporary output files. By default, the temporary directory is set to '/lscratch/$SLURM_JOBID' on NIH's Biowulf cluster and 'OUTPUT' on the FRCE cluster. However, if you are running the pipeline on another cluster, this option will need to be specified. Ideally, this path should point to a dedicated location on the filesystem for writing tmp files. On many systems, this location is set to somewhere in /scratch. If you need to inject avariable into this string that should NOT be expanded,please quote this options value in single quotes.
 >
 > **_Example:_** `--tmp-dir /cluster_scratch/$USER/`
 

--- a/docs/RNA-seq/build.md
+++ b/docs/RNA-seq/build.md
@@ -1,13 +1,15 @@
 # <code>renee <b>build</b></code>
 
-## 1. About 
+## 1. About
+
 The `renee` executable is composed of several inter-related sub commands. Please see `renee -h` for all available options.
 
-This part of the documentation describes options and concepts for <code>renee <b>build</b></code> sub command in more detail. With minimal configuration, the **`build`** sub command enables you to build new reference files for the renee run pipeline.    
+This part of the documentation describes options and concepts for <code>renee <b>build</b></code> sub command in more detail. With minimal configuration, the **`build`** sub command enables you to build new reference files for the renee run pipeline.
 
-Setting up the RENEE build pipeline is fast and easy! In its most basic form, <code>renee <b>build</b></code> only has *five required inputs*.
+Setting up the RENEE build pipeline is fast and easy! In its most basic form, <code>renee <b>build</b></code> only has _five required inputs_.
 
 ## 2. Synopsis
+
 ```text
 $ renee build [--help] \
              [--shared-resources SHARED_RESOURCES] [--small-genome] \
@@ -24,152 +26,169 @@ The synopsis for each command shows its parameters and their usage. Optional par
 
 A user **must** provide the genomic sequence of the reference's assembly in FASTA format via `--ref-fa` argument, an alias for the reference genome via `--ref-name` argument, a gene annotation for the reference assembly via `--ref-gtf` argument, an alias or version for the gene annotation via the ` --gtf-ver` argument, and an output directory to store the built reference files via `--output` argument. If you are running the pipeline outside of Biowulf, you will need to additionally provide the the following options: `--shared-resources`, `--tmp-dir`. More information about each of these options can be found below.
 
-For [human](https://www.gencodegenes.org/human/) and [mouse](https://www.gencodegenes.org/mouse/) data, we highly recommend downloading the latest available **PRI** genome assembly and corresponding gene annotation from [GENCODE](https://www.gencodegenes.org/). These reference files contain chromosomes and scaffolds sequences. 
+For [human](https://www.gencodegenes.org/human/) and [mouse](https://www.gencodegenes.org/mouse/) data, we highly recommend downloading the latest available **PRI** genome assembly and corresponding gene annotation from [GENCODE](https://www.gencodegenes.org/). These reference files contain chromosomes and scaffolds sequences.
 
- The build pipeline will generate a JSON file containing key, value pairs to required reference files for the <code>renee <b>run</b></code> pipeline. This file will be located in the path provided to `--output`. The name of this JSON file is dependent on the values provided to `--ref-name` and `--gtf-ver` and has the following naming convention: `{OUTPUT}/{REF_NAME}_{GTF_VER}.json`. Once the build pipeline completes, this reference JSON file can be passed to the `--genome` option of <code>renee <b>run</b></code>. This is how new references are built for the RENEE pipeline. 
+The build pipeline will generate a JSON file containing key, value pairs to required reference files for the <code>renee <b>run</b></code> pipeline. This file will be located in the path provided to `--output`. The name of this JSON file is dependent on the values provided to `--ref-name` and `--gtf-ver` and has the following naming convention: `{OUTPUT}/{REF_NAME}_{GTF_VER}.json`. Once the build pipeline completes, this reference JSON file can be passed to the `--genome` option of <code>renee <b>run</b></code>. This is how new references are built for the RENEE pipeline.
 
-Use you can always use the `-h` option for information on a specific command. 
+Use you can always use the `-h` option for information on a specific command.
 
 ### 2.1 Required Arguments
 
 Each of the following arguments are required. Failure to provide a required argument will result in a non-zero exit-code.
 
-  `--ref-fa REF_FA`  
+`--ref-fa REF_FA`
+
 > **Genomic FASTA file of the reference genome.**  
-> *type: file*
-> 
-> This file represents the genome sequence of the reference assembly in FASTA format. If you are downloading this from GENCODE, you should select the *PRI* genomic FASTA file. This file will contain the primary genomic assembly (contains chromosomes and scaffolds). This input file should not be compressed. Sequence identifers in this file must match with sequence identifers in the GTF file provided to `--ref-gtf`.  
-> 
-> ***Example:***
-> `--ref-fa GRCh38.primary_assembly.genome.fa`
-
-
----  
-  `--ref-name REF_NAME`  
-> **Name of the reference genome.**  
-> *type: string*
-> 
-> Name or alias for the reference genome. This can be the common name for the reference genome. Here is a list of common examples for different model organisms: mm10, hg38, rn6, danRer11, dm6, canFam3, sacCer3, ce11. If the provided values contains one of the following sub-strings (hg19, hs37d, grch37, hg38, hs38d, grch38, mm10, grcm38), then Arriba will run with its corresponding blacklist. 
-> 
-> ***Example:*** `--ref-name hg38`
-
---- 
-  `--ref-gtf REF_GTF`  
-> **Gene annotation or GTF file for the reference genome.**  
-> *type: file*
-> 
-> This file represents the reference genome's gene annotation in GTF format. If you are downloading this from GENCODE, you should select the 'PRI' GTF file. This file contains gene annotations for the primary assembly (contains chromosomes and scaffolds). This input file should not be compressed. Sequence identifers (column 1) in this file must match with sequence identifers in the FASTA file provided to `--ref-fa`.  
-> ***Example:***  `--ref-gtf gencode.v36.primary_assembly.annotation.gtf`
+> _type: file_
+>
+> This file represents the genome sequence of the reference assembly in FASTA format. If you are downloading this from GENCODE, you should select the _PRI_ genomic FASTA file. This file will contain the primary genomic assembly (contains chromosomes and scaffolds). This input file should not be compressed. Sequence identifers in this file must match with sequence identifers in the GTF file provided to `--ref-gtf`.
+>
+> **_Example:_** > `--ref-fa GRCh38.primary_assembly.genome.fa`
 
 ---
-  `--gtf-ver GTF_VER`  
+
+`--ref-name REF_NAME`
+
+> **Name of the reference genome.**  
+> _type: string_
+>
+> Name or alias for the reference genome. This can be the common name for the reference genome. Here is a list of common examples for different model organisms: mm10, hg38, rn6, danRer11, dm6, canFam3, sacCer3, ce11. If the provided values contains one of the following sub-strings (hg19, hs37d, grch37, hg38, hs38d, grch38, mm10, grcm38), then Arriba will run with its corresponding blacklist.
+>
+> **_Example:_** `--ref-name hg38`
+
+---
+
+`--ref-gtf REF_GTF`
+
+> **Gene annotation or GTF file for the reference genome.**  
+> _type: file_
+>
+> This file represents the reference genome's gene annotation in GTF format. If you are downloading this from GENCODE, you should select the 'PRI' GTF file. This file contains gene annotations for the primary assembly (contains chromosomes and scaffolds). This input file should not be compressed. Sequence identifers (column 1) in this file must match with sequence identifers in the FASTA file provided to `--ref-fa`.  
+> **_Example:_** `--ref-gtf gencode.v36.primary_assembly.annotation.gtf`
+
+---
+
+`--gtf-ver GTF_VER`
+
 > **Version of the gene annotation or GTF file provided.**  
-> *type: string or int*
-> 
-> This is the version of the supplied gene annotation or GTF file. If you are using a GTF file from GENCODE, use the release number or version (i.e. *M25* for mouse or *37* for human). Visit gencodegenes.org for more details.  
-> ***Example:*** `--gtf-ver 36`
-  
---- 
-  `--output OUTPUT`
+> _type: string or int_
+>
+> This is the version of the supplied gene annotation or GTF file. If you are using a GTF file from GENCODE, use the release number or version (i.e. _M25_ for mouse or _37_ for human). Visit gencodegenes.org for more details.  
+> **_Example:_** `--gtf-ver 36`
+
+---
+
+`--output OUTPUT`
+
 > **Path to an output directory.**  
-> *type: path*
->   
+> _type: path_
+>
 > This location is where the build pipeline will create all of its output files. If the user-provided working directory has not been initialized, it will automatically be created.  
-> ***Example:*** `--output /data/$USER/refs/hg38_v36/`
+> **_Example:_** `--output /data/$USER/refs/hg38_v36/`
 
 ### 2.2 Build Options
 
 Each of the following arguments are optional and do not need to be provided. If you are running the pipeline outside of Biowulf, the `--shared-resources` option only needs to be provided at least once. This will ensure reference files that are shared across different genomes are downloaded locally.
 
-  `--shared-resources SHARED_RESOURCES`  
-> **Local path to shared resources.**  
-> *type: path*
->
-> The pipeline uses a set of shared reference files that can be re-used across reference genomes. These currently include reference files for kraken and FQScreen. These reference files can be downloaded with the build sub command's `--shared-resources`  option. With that being said, these files only need to be downloaded once. We recommend storing this files in a shared location on the filesystem that other people can access. If you are running the pipeline on Biowulf, you do NOT need to download these reference files! They already exist on the filesystem in a location that anyone can acceess; however, if you are running the pipeline on another cluster or target system, you will need to download the shared resources with the build sub command, and you will need to provide this option every time you run the pipeline. Please provide the same path that was provided to the build sub command's --shared-resources option. Again, if you are running the pipeline on Biowulf, you do NOT need to provide this option. For more information about how to download shared resources, please reference the build sub command's `--shared-resources` option.
-> 
-> ***Example:*** `--shared-resources /data/shared/renee`
+`--shared-resources SHARED_RESOURCES`
 
----  
-  `--small-genome`            
+> **Local path to shared resources.**  
+> _type: path_
+>
+> The pipeline uses a set of shared reference files that can be re-used across reference genomes. These currently include reference files for kraken and FQScreen. These reference files can be downloaded with the build sub command's `--shared-resources` option. With that being said, these files only need to be downloaded once. We recommend storing this files in a shared location on the filesystem that other people can access. If you are running the pipeline on Biowulf, you do NOT need to download these reference files! They already exist on the filesystem in a location that anyone can acceess; however, if you are running the pipeline on another cluster or target system, you will need to download the shared resources with the build sub command, and you will need to provide this option every time you run the pipeline. Please provide the same path that was provided to the build sub command's --shared-resources option. Again, if you are running the pipeline on Biowulf, you do NOT need to provide this option. For more information about how to download shared resources, please reference the build sub command's `--shared-resources` option.
+>
+> **_Example:_** `--shared-resources /data/shared/renee`
+
+---
+
+`--small-genome`
+
 > **Builds a small genome index.**  
-> *type: boolean*
-> 
+> _type: boolean_
+>
 > For small genomes, it is recommeded running STAR with a scaled down `--genomeSAindexNbases` value. This option runs the build pipeline in a mode where it dynamically finds the optimal value for this option using the following formula: `min(14, log2(GenomeSize)/2 - 1)`. Generally speaking, this option is not really applicable for most mammalian reference genomes, i.e. human and mouse; however, researcher working with very small reference genomes, like S. cerevisiae ~ 12Mb, should provide this option.
 >
-> When in doubt feel free to provide this option, as the optimal value will be found based on your input. 
+> When in doubt feel free to provide this option, as the optimal value will be found based on your input.
 >
-> ***Example:*** `--small-genome`
+> **_Example:_** `--small-genome`
 
 ### 2.3 Orchestration Options
 
-  `--dry-run`            
+`--dry-run`
+
 > **Dry run the build pipeline.**  
-> *type: boolean*
-> 
+> _type: boolean_
+>
 > Displays what steps in the build pipeline remain or will be run. Does not execute anything!
 >
-> ***Example:*** `--dry-run`
+> **_Example:_** `--dry-run`
 
---- 
-  `--singularity-cache SINGULARITY_CACHE`  
+---
+
+`--singularity-cache SINGULARITY_CACHE`
+
 > **Overrides the $SINGULARITY_CACHEDIR environment variable.**  
-> *type: path*  
-> *default: `--output OUTPUT/.singularity`*
+> _type: path_  
+> _default: `--output OUTPUT/.singularity`_
 >
-> Singularity will cache image layers pulled from remote registries. This ultimately speeds up the process of pull an image from DockerHub if an image layer already exists in the singularity cache directory. By default, the cache is set to the value provided to the `--output` argument. Please note that this cache cannot be shared across users. Singularity strictly enforces you own the cache directory and will return a non-zero exit code if you do not own the cache directory! See the `--sif-cache` option to create a shareable resource. 
-> 
-> ***Example:*** `--singularity-cache /data/$USER/.singularity`
+> Singularity will cache image layers pulled from remote registries. This ultimately speeds up the process of pull an image from DockerHub if an image layer already exists in the singularity cache directory. By default, the cache is set to the value provided to the `--output` argument. Please note that this cache cannot be shared across users. Singularity strictly enforces you own the cache directory and will return a non-zero exit code if you do not own the cache directory! See the `--sif-cache` option to create a shareable resource.
+>
+> **_Example:_** `--singularity-cache /data/$USER/.singularity`
 
----  
-  `--sif-cache SIF_CACHE`
+---
+
+`--sif-cache SIF_CACHE`
+
 > **Path where a local cache of SIFs are stored.**  
-> *type: path*  
+> _type: path_
 >
 > Uses a local cache of SIFs on the filesystem. This SIF cache can be shared across users if permissions are set correctly. If a SIF does not exist in the SIF cache, the image will be pulled from Dockerhub and a warning message will be displayed. The `renee cache` subcommand can be used to create a local SIF cache. Please see `renee cache` for more information. This command is extremely useful for avoiding DockerHub pull rate limits. It also remove any potential errors that could occur due to network issues or DockerHub being temporarily unavailable. We recommend running RENEE with this option when ever possible.
-> 
-> ***Example:*** `--singularity-cache /data/$USER/SIFs`
-> 
+>
+> **_Example:_** `--singularity-cache /data/$USER/SIFs`
 
----  
-  `--tmp-dir TMP_DIR`   
+---
+
+`--tmp-dir TMP_DIR`
+
 > **Path on the file system for writing temporary files.**  
-> *type: path*  
-> *default: `/lscratch/$SLURM_JOBID`*
-> 
-> This is a path on the file system for writing temporary output files. By default, the temporary directory is set to '/lscratch/$SLURM_JOBID' for backwards compatibility with the NIH's Biowulf cluster; however, if you are running the pipeline on another cluster, this option will need to be specified. Ideally, this path should point to a dedicated location on the filesystem for writing tmp files. On many systems, this location is set to somewhere in /scratch. If you need to inject a variable into this string that should NOT be expanded, please quote this options value in single quotes. Again, if you are running the pipeline on Biowulf, you do NOT need to provide this option. 
-> 
-> ***Example:*** `--tmp-dir /cluster_scratch/$USER/`
+> _type: path_  
+> _default: `/lscratch/$SLURM_JOBID`_
+>
+> Path on the file system for writing temporary output files. By default, the temporary directory is set to '/lscratch/$SLURM_JOBID' on NIH's Biowulf cluster and 'outdir' on the FRCE cluster. However, if you are running the pipeline on another cluster, this option will need to be specified. Ideally, this path should point to a dedicated location on the filesystem for writing tmp files. On many systems, this location is set to somewhere in /scratch. If you need to inject avariable into this string that should NOT be expanded,please quote this options value in single quotes.
+>
+> **_Example:_** `--tmp-dir /cluster_scratch/$USER/`
 
 ### 2.4 Misc Options
 
-Each of the following arguments are optional and do not need to be provided. 
+Each of the following arguments are optional and do not need to be provided.
 
-  `-h, --help`            
+`-h, --help`
+
 > **Display Help.**  
-> *type: boolean*
-> 
+> _type: boolean_
+>
 > Shows command's synopsis, help message, and an example command
-> 
-> ***Example:*** `--help`
+>
+> **_Example:_** `--help`
 
-## 3. Hybrid Genomes  
+## 3. Hybrid Genomes
 
-If you have two GTF files, e.g. hybrid genomes (host + virus), then you need to create one genomic FASTA file and one GTF file for the hybrid genome prior to running the <code>renee <b>build</b></code> command. 
+If you have two GTF files, e.g. hybrid genomes (host + virus), then you need to create one genomic FASTA file and one GTF file for the hybrid genome prior to running the <code>renee <b>build</b></code> command.
 
 We recommend creating an artifical chromosome for the non-host sequence. The sequence identifer in the FASTA file must match the sequence identifer in the GTF file (column 1). Generally speaking, since the host annotation is usually downloaded from Ensembl or GENCODE, it will be correctly formatted; however, that may not be the case for the non-host sequence!
 
-Please ensure the non-host annotation contains the following features and/or constraints:   
+Please ensure the non-host annotation contains the following features and/or constraints:
 
- * for a given `gene` feature   
-     * each `gene` entry has at least one `transcript` feature    
-     * and each `transcript` entry has atleast one `exon` feature
-     * `gene_id`, `gene_name` and `gene_biotype` are required
- * for a given `transcipt` feature
-     * along with `gene_id`, `gene_name` and `gene_biotype` ... `transcript_id` is also required
- * for a given `exon` feature
-     * `gene_id`, `gene_name`, `gene_biotype`, `transcript_id` are required
+- for a given `gene` feature
+  - each `gene` entry has at least one `transcript` feature
+  - and each `transcript` entry has atleast one `exon` feature
+  - `gene_id`, `gene_name` and `gene_biotype` are required
+- for a given `transcipt` feature
+  - along with `gene_id`, `gene_name` and `gene_biotype` ... `transcript_id` is also required
+- for a given `exon` feature
+  - `gene_id`, `gene_name`, `gene_biotype`, `transcript_id` are required
 
-If not, the GTF file may need to be manually curated until these conditions are satisfied. 
+If not, the GTF file may need to be manually curated until these conditions are satisfied.
 
 Here is an example feature from a hand-curated Biotyn_probe GTF file:
 
@@ -179,20 +198,19 @@ Biot1   BiotynProbe transcript  1   21  0.000000    +   .   gene_id "Biot1"; gen
 Biot1   BiotynProbe exon    1   21  0.000000    +   .   gene_id "Biot1"; gene_biotype "biotynlated_probe_control"; transcript_id "Biot1"; transcript_type "biotynlated_probe_control";
 ```
 
-In this tab-delimited example above, 
+In this tab-delimited example above,
 
- * ***line 1:*** the `gene` feature has 3 required attributes in column 9: `gene_id` and `gene_name` and `gene_biotype`
- * ***line 2:*** the `transcript` entry for the above `gene` repeats the same attributes with following required fields: `transcript_id ` and `transcript_name`
-     * *Please note:* `transcript_type` is *optional*
- * ***line 3:*** the `exon` entry for the above `transcript` has 3 required attributes: `gene_id` and `transcript_id` and `gene_biotype`
-     * *Please note:* `transcript_type` is *optional*
+- **_line 1:_** the `gene` feature has 3 required attributes in column 9: `gene_id` and `gene_name` and `gene_biotype`
+- **_line 2:_** the `transcript` entry for the above `gene` repeats the same attributes with following required fields: `transcript_id ` and `transcript_name`
+  - _Please note:_ `transcript_type` is _optional_
+- **_line 3:_** the `exon` entry for the above `transcript` has 3 required attributes: `gene_id` and `transcript_id` and `gene_biotype`
+  - _Please note:_ `transcript_type` is _optional_
 
-For a given gene, the combination of the `gene_id` AND `gene_name` should form a unique string. There should be no instances where two different genes share the same `gene_id` AND `gene_name`. 
-
+For a given gene, the combination of the `gene_id` AND `gene_name` should form a unique string. There should be no instances where two different genes share the same `gene_id` AND `gene_name`.
 
 ## 4. Convert NCBI GFF3 to GTF format
 
-It is worth noting that RENEE comes bundled with a script to convert GFF3 files downloaded from NCBI to GTF file format. This convenience script is useful as the `renee build` sub command takes a GTF file as one of its inputs. 
+It is worth noting that RENEE comes bundled with a script to convert GFF3 files downloaded from NCBI to GTF file format. This convenience script is useful as the `renee build` sub command takes a GTF file as one of its inputs.
 
 Please note that this script has only been tested with GFF3 files downloaded from NCBI, and _it is **not** recommended to use with GFF3 files originating from other sources like Ensembl or GENCODE_. If you are selecting an annotation from Ensembl or GENCODE, please download the GTF file option.
 
@@ -204,17 +222,18 @@ pip install argparse
 ```
 
 For more information about the script and its usage, please run:
+
 ```bash
 ./resources/gff3togtf.py -h
 ```
 
 ## 5. Example
 
-### 5.1 Biowulf 
+### 5.1 Biowulf
 
-On Biowulf getting started with the pipeline is fast and easy! In this example, we build a mouse reference genome. 
+On Biowulf getting started with the pipeline is fast and easy! In this example, we build a mouse reference genome.
 
-```bash 
+```bash
 # Step 0.) Grab an interactive node (do not run on head node)
 srun -N 1 -n 1 --time=2:00:00 -p interactive --mem=8gb  --cpus-per-task=4 --pty bash
 module purge
@@ -229,20 +248,20 @@ renee build --ref-fa GRCm39.primary_assembly.genome.fa \
               --sif-cache /data/CCBR_Pipeliner/SIFs/ \
               --dry-run
 
-# Step 2.) Build new RENEE reference files 
+# Step 2.) Build new RENEE reference files
 renee build --ref-fa GRCm39.primary_assembly.genome.fa \
               --ref-name mm39 \
               --ref-gtf gencode.vM26.annotation.gtf \
               --gtf-ver M26 \
               --output /data/$USER/refs/mm39_M26 \
-              --sif-cache /data/CCBR_Pipeliner/SIFs/ 
+              --sif-cache /data/CCBR_Pipeliner/SIFs/
 ```
 
 ### 5.2 Generic SLURM Cluster
 
-Running the pipeline outside of Biowulf is easy; however, there are a few extra options you must provide. Please note when running the build sub command for the first time, you will also need to provide the `--shared-resources` option. This option will download our kraken2 database and bowtie2 indices for FastQ Screen. The path provided to this option should be provided to the `--shared-resources` option of the [run](./RNA-seq/cache/) sub command. Next, you will also need to provide a path to write temporary output files via the `--tmp-dir` option. We also recommend providing a path to a SIF cache. You can cache software containers locally with the [cache](./RNA-seq/cache/) sub command. 
+Running the pipeline outside of Biowulf is easy; however, there are a few extra options you must provide. Please note when running the build sub command for the first time, you will also need to provide the `--shared-resources` option. This option will download our kraken2 database and bowtie2 indices for FastQ Screen. The path provided to this option should be provided to the `--shared-resources` option of the [run](./RNA-seq/cache/) sub command. Next, you will also need to provide a path to write temporary output files via the `--tmp-dir` option. We also recommend providing a path to a SIF cache. You can cache software containers locally with the [cache](./RNA-seq/cache/) sub command.
 
-```bash 
+```bash
 # Step 0.) Grab an interactive node (do not run on head node)
 srun -N 1 -n 1 --time=2:00:00 -p interactive --mem=8gb  --cpus-per-task=4 --pty bash
 # Add snakemake and singularity to $PATH,
@@ -270,7 +289,7 @@ renee build --ref-fa GRCm39.primary_assembly.genome.fa \
               --sif-cache /data/$USER/cache \
               --dry-run
 
-# Step 2.) Build new RENEE reference files 
+# Step 2.) Build new RENEE reference files
 renee build --ref-fa GRCm39.primary_assembly.genome.fa \
               --ref-name mm39 \
               --ref-gtf gencode.vM26.annotation.gtf \
@@ -278,5 +297,5 @@ renee build --ref-fa GRCm39.primary_assembly.genome.fa \
               --output /data/$USER/refs/mm39_M26 \
               --shared-resources /data/shared/renee \
               --tmp-dir /cluster_scratch/$USER/ \
-              --sif-cache /data/$USER/cache 
+              --sif-cache /data/$USER/cache
 ```

--- a/docs/RNA-seq/run.md
+++ b/docs/RNA-seq/run.md
@@ -169,7 +169,7 @@ Each of the following arguments are optional and do not need to be provided.
 > _type: path_  
 > _default: `/lscratch/$SLURM_JOBID`_
 >
-> Path on the file system for writing temporary output files. By default, the temporary directory is set to '/lscratch/$SLURM_JOBID' on NIH's Biowulf cluster and 'outdir' on the FRCE cluster. However, if you are running the pipeline on another cluster, this option will need to be specified. Ideally, this path should point to a dedicated location on the filesystem for writing tmp files. On many systems, this location is set to somewhere in /scratch. If you need to inject avariable into this string that should NOT be expanded,please quote this options value in single quotes.
+> Path on the file system for writing temporary output files. By default, the temporary directory is set to '/lscratch/$SLURM_JOBID' on NIH's Biowulf cluster and 'OUTPUT' on the FRCE cluster. However, if you are running the pipeline on another cluster, this option will need to be specified. Ideally, this path should point to a dedicated location on the filesystem for writing tmp files. On many systems, this location is set to somewhere in /scratch. If you need to inject avariable into this string that should NOT be expanded,please quote this options value in single quotes.
 >
 > **_Example:_** --tmp-dir '/cluster_scratch/$USER/'
 

--- a/docs/RNA-seq/run.md
+++ b/docs/RNA-seq/run.md
@@ -1,13 +1,15 @@
 # <code>renee <b>run</b></code>
 
-## 1. About 
+## 1. About
+
 The `renee` executable is composed of several inter-related sub commands. Please see `renee -h` for all available options.
 
-This part of the documentation describes options and concepts for <code>renee <b>run</b></code> sub command in more detail. With minimal configuration, the **`run`** sub command enables you to start running the data processing and quality-control pipeline. 
+This part of the documentation describes options and concepts for <code>renee <b>run</b></code> sub command in more detail. With minimal configuration, the **`run`** sub command enables you to start running the data processing and quality-control pipeline.
 
-Setting up the RENEE pipeline is fast and easy! In its most basic form, <code>renee <b>run</b></code> only has *three required inputs*.
+Setting up the RENEE pipeline is fast and easy! In its most basic form, <code>renee <b>run</b></code> only has _three required inputs_.
 
 ## 2. Synopsis
+
 ```text
 $ renee run [--help] \
             [--small-rna] [--star-2-pass-basic] \
@@ -26,163 +28,183 @@ The synopsis for each command shows its parameters and their usage. Optional par
 
 A user **must** provide a list of FastQ files (globbing is supported) to analyze via `--input` argument, an output directory to store results via `--output` argument and select reference genome for alignment and annotation via the `--genome` argument. If you are running the pipeline outside of Biowulf, you will need to additionally provide the the following options: `--shared-resources`, `--tmp-dir`. More information about each of these options can be found below.
 
-Use you can always use the `-h` option for information on a specific sub command.  
+Use you can always use the `-h` option for information on a specific sub command.
 
 ### 2.1 Required Arguments
 
 Each of the following arguments are required. Failure to provide a required argument will result in a non-zero exit-code.
 
-  `--input INPUT [INPUT ...]`  
+`--input INPUT [INPUT ...]`
+
 > **Input FastQ file(s) to process.**  
-> *type: file*  
-> 
-> One or more FastQ files can be provided. From the command-line, each FastQ file should seperated by a space. Globbing is supported! This makes selecting FastQ files easier. Input FastQ files should be gzipp-ed. The pipeline supports single-end and pair-end RNA-seq data; however, the pipeline will not process a mixture of single-end and paired-end samples together. If you have a mixture of single-end and pair-end samples to process, please process them as two seperate instances of the RENEE pipeline (with two seperate output directories).   
-> 
-> ***Example:*** `--input .tests/*.R?.fastq.gz`
-
----  
-  `--output OUTPUT`
-> **Path to an output directory.**   
-> *type: path*
->   
-> This location is where the pipeline will create all of its output files, also known as the pipeline's working directory. If the provided output directory does not exist, it will be initialized automatically.
-> 
-> ***Example:*** `--output /data/$USER/RNA_hg38`
-
----  
-  `--genome {hg38_30,mm10_M21,custom.json}`
-> **Reference genome.**   
-> *type: string or file*
->   
-> This option defines the reference genome for your set of samples. On Biowulf, RENEE does comes bundled with pre built reference files for human and mouse samples; however, it is worth noting that the pipeline does accept a custom reference genome built with the build sub command. Building a new reference genome is easy! You can create a custom reference genome with a single command. This is extremely useful when working with non-model organisms. New users can reference the documentation's [getting started](../TLDR-RNA-seq/#3-building-reference-files) section to see how a reference genome is built. 
+> _type: file_
 >
-> ***Pre built Option***  
+> One or more FastQ files can be provided. From the command-line, each FastQ file should seperated by a space. Globbing is supported! This makes selecting FastQ files easier. Input FastQ files should be gzipp-ed. The pipeline supports single-end and pair-end RNA-seq data; however, the pipeline will not process a mixture of single-end and paired-end samples together. If you have a mixture of single-end and pair-end samples to process, please process them as two seperate instances of the RENEE pipeline (with two seperate output directories).
+>
+> **_Example:_** `--input .tests/*.R?.fastq.gz`
+
+---
+
+`--output OUTPUT`
+
+> **Path to an output directory.**  
+> _type: path_
+>
+> This location is where the pipeline will create all of its output files, also known as the pipeline's working directory. If the provided output directory does not exist, it will be initialized automatically.
+>
+> **_Example:_** `--output /data/$USER/RNA_hg38`
+
+---
+
+`--genome {hg38_30,mm10_M21,custom.json}`
+
+> **Reference genome.**  
+> _type: string or file_
+>
+> This option defines the reference genome for your set of samples. On Biowulf, RENEE does comes bundled with pre built reference files for human and mouse samples; however, it is worth noting that the pipeline does accept a custom reference genome built with the build sub command. Building a new reference genome is easy! You can create a custom reference genome with a single command. This is extremely useful when working with non-model organisms. New users can reference the documentation's [getting started](../TLDR-RNA-seq/#3-building-reference-files) section to see how a reference genome is built.
+>
+> **_Pre built Option_**  
 > Pre build genomes are avaiable with RENEE. Please see the [resources page](../Resources/#1.-Reference-genomes) for more information about each pre built option.
 >
-> ***Custom Option***   
-> A user can also supply a custom reference genome built with the build sub command. Please supply the custom reference JSON file that was generated by the build sub command. The name of this custom reference JSON file is dependent on the values provided to the following *renee build* args, `--ref-name REF_NAME` and `--gtf-ver GTF_VER`, where the name of the provided custom reference JSON file would be: `{REF_NAME}_{GTF_VER}.json`.
->   
-> ***Example:*** `--genome hg38_30` *OR* `--genome /data/${USER}/hg38_36/hg38_36.json`  
+> **_Custom Option_**  
+> A user can also supply a custom reference genome built with the build sub command. Please supply the custom reference JSON file that was generated by the build sub command. The name of this custom reference JSON file is dependent on the values provided to the following _renee build_ args, `--ref-name REF_NAME` and `--gtf-ver GTF_VER`, where the name of the provided custom reference JSON file would be: `{REF_NAME}_{GTF_VER}.json`.
+>
+> **_Example:_** `--genome hg38_30` _OR_ `--genome /data/${USER}/hg38_36/hg38_36.json`
 
 ### 2.2 Analysis Options
 
-  `--small-rna`  
-> **Run STAR using ENCODE's recomendations for small RNA.**  
-> *type: boolean*
-> 
-> This option should only be used with small RNA libraries. These are rRNA-depleted libraries that have been size selected to contain fragments shorter than 200bp. Size selection enriches for small RNA species such as miRNAs, siRNAs, or piRNAs. Also, this option should not be combined with the star 2-pass basic option. If the two options are combined, STAR will run in pass basic mode. This means that STAR will not run with ENCODE's recommendations for small RNA alignment. As so, please take caution not to combine both options together. 
-> 
-> Please note: This option is only supported with single-end data. 
->
-> ***Example:*** `--small-rna`
+`--small-rna`
 
----  
-  `--star-2-pass-basic`  
+> **Run STAR using ENCODE's recomendations for small RNA.**  
+> _type: boolean_
+>
+> This option should only be used with small RNA libraries. These are rRNA-depleted libraries that have been size selected to contain fragments shorter than 200bp. Size selection enriches for small RNA species such as miRNAs, siRNAs, or piRNAs. Also, this option should not be combined with the star 2-pass basic option. If the two options are combined, STAR will run in pass basic mode. This means that STAR will not run with ENCODE's recommendations for small RNA alignment. As so, please take caution not to combine both options together.
+>
+> Please note: This option is only supported with single-end data.
+>
+> **_Example:_** `--small-rna`
+
+---
+
+`--star-2-pass-basic`
+
 > **Run STAR in per sample 2-pass mapping mode.**  
-> *type: boolean*
-> 
-> It is recommended to use this option when processing a set of unrelated samples or when processing samples in a clinical setting. It is not adivsed to use this option for a study with multiple related samples. 
-> 
+> _type: boolean_
+>
+> It is recommended to use this option when processing a set of unrelated samples or when processing samples in a clinical setting. It is not adivsed to use this option for a study with multiple related samples.
+>
 > By default, the pipeline ultilizes a multi sample 2-pass mapping approach where the set of splice junctions detected across all samples are provided to the second pass of STAR. This option overrides the default behavior so each sample will be processed in a per sample two-pass basic mode. This option should not be combined with the small RNA option. If the two options are combined, STAR will run in pass basic mode.
-> 
-> ***Example:*** `--star-2-pass-basic`
+>
+> **_Example:_** `--star-2-pass-basic`
 
 ### 2.3 Orchestration Options
 
-Each of the following arguments are optional and do not need to be provided. 
-  
-  `--dry-run`            
+Each of the following arguments are optional and do not need to be provided.
+
+`--dry-run`
+
 > **Dry run the pipeline.**  
-> *type: boolean*
-> 
+> _type: boolean_
+>
 > Displays what steps in the pipeline remain or will be run. Does not execute anything!
 >
-> ***Example:*** `--dry-run`
+> **_Example:_** `--dry-run`
 
----  
-  `--mode {slurm,local}`  
-> **Execution Method.** 
-> *type: string*  
-> *default: slurm*  
-> 
-> Execution Method. Defines the mode or method of execution. Vaild mode options include: slurm or local. 
-> 
-> ***local***  
-> Local executions will run serially on compute instance. This is useful for testing, debugging, or when a users does not have access to a high performance computing environment. If this option is not provided, it will default to a local execution mode. 
-> 
-> ***slurm***    
+---
+
+`--mode {slurm,local}`
+
+> **Execution Method.** > _type: string_  
+> _default: slurm_
+>
+> Execution Method. Defines the mode or method of execution. Vaild mode options include: slurm or local.
+>
+> **_local_**  
+> Local executions will run serially on compute instance. This is useful for testing, debugging, or when a users does not have access to a high performance computing environment. If this option is not provided, it will default to a local execution mode.
+>
+> **_slurm_**  
 > The slurm execution method will submit jobs to a cluster using a slurm + singularity backend. This method will automatically submit the master job to the cluster. It is recommended running RENEE in this mode as execution will be significantly faster in a distributed environment.
-> 
-> ***Example:*** `--mode slurm`
+>
+> **_Example:_** `--mode slurm`
 
----  
-  `--shared-resources SHARED_RESOURCES`  
+---
+
+`--shared-resources SHARED_RESOURCES`
+
 > **Local path to shared resources.**  
-> *type: path*
+> _type: path_
 >
-> The pipeline uses a set of shared reference files that can be re-used across reference genomes. These currently include reference files for kraken and FQScreen. These reference files can be downloaded with the build sub command's `--shared-resources`  option. With that being said, these files only need to be downloaded once. We recommend storing this files in a shared location on the filesystem that other people can access. If you are running the pipeline on Biowulf, you do NOT need to download these reference files! They already exist on the filesystem in a location that anyone can acceess; however, if you are running the pipeline on another cluster or target system, you will need to download the shared resources with the build sub command, and you will need to provide this option every time you run the pipeline. Please provide the same path that was provided to the build sub command's --shared-resources option. Again, if you are running the pipeline on Biowulf, you do NOT need to provide this option. For more information about how to download shared resources, please reference the build sub command's `--shared-resources` option.
-> 
-> ***Example:*** `--shared-resources /data/shared/renee`
+> The pipeline uses a set of shared reference files that can be re-used across reference genomes. These currently include reference files for kraken and FQScreen. These reference files can be downloaded with the build sub command's `--shared-resources` option. With that being said, these files only need to be downloaded once. We recommend storing this files in a shared location on the filesystem that other people can access. If you are running the pipeline on Biowulf, you do NOT need to download these reference files! They already exist on the filesystem in a location that anyone can acceess; however, if you are running the pipeline on another cluster or target system, you will need to download the shared resources with the build sub command, and you will need to provide this option every time you run the pipeline. Please provide the same path that was provided to the build sub command's --shared-resources option. Again, if you are running the pipeline on Biowulf, you do NOT need to provide this option. For more information about how to download shared resources, please reference the build sub command's `--shared-resources` option.
+>
+> **_Example:_** `--shared-resources /data/shared/renee`
 
----  
-  `--singularity-cache SINGULARITY_CACHE`  
+---
+
+`--singularity-cache SINGULARITY_CACHE`
+
 > **Overrides the $SINGULARITY_CACHEDIR environment variable.**  
-> *type: path*  
-> *default: `--output OUTPUT/.singularity`*
+> _type: path_  
+> _default: `--output OUTPUT/.singularity`_
 >
-> Singularity will cache image layers pulled from remote registries. This ultimately speeds up the process of pull an image from DockerHub if an image layer already exists in the singularity cache directory. By default, the cache is set to the value provided to the `--output` argument. Please note that this cache cannot be shared across users. Singularity strictly enforces you own the cache directory and will return a non-zero exit code if you do not own the cache directory! See the `--sif-cache` option to create a shareable resource. 
-> 
-> ***Example:*** `--singularity-cache /data/$USER/.singularity`
+> Singularity will cache image layers pulled from remote registries. This ultimately speeds up the process of pull an image from DockerHub if an image layer already exists in the singularity cache directory. By default, the cache is set to the value provided to the `--output` argument. Please note that this cache cannot be shared across users. Singularity strictly enforces you own the cache directory and will return a non-zero exit code if you do not own the cache directory! See the `--sif-cache` option to create a shareable resource.
+>
+> **_Example:_** `--singularity-cache /data/$USER/.singularity`
 
----  
-  `--sif-cache SIF_CACHE`
+---
+
+`--sif-cache SIF_CACHE`
+
 > **Path where a local cache of SIFs are stored.**  
-> *type: path*  
+> _type: path_
 >
 > Uses a local cache of SIFs on the filesystem. This SIF cache can be shared across users if permissions are set correctly. If a SIF does not exist in the SIF cache, the image will be pulled from Dockerhub and a warning message will be displayed. The `renee cache` subcommand can be used to create a local SIF cache. Please see `renee cache` for more information. This command is extremely useful for avoiding DockerHub pull rate limits. It also remove any potential errors that could occur due to network issues or DockerHub being temporarily unavailable. We recommend running RENEE with this option when ever possible.
-> 
-> ***Example:*** `--singularity-cache /data/$USER/SIFs`
+>
+> **_Example:_** `--singularity-cache /data/$USER/SIFs`
 
----  
-  `--tmp-dir TMP_DIR`   
+---
+
+`--tmp-dir TMP_DIR`
+
 > **Path on the file system for writing temporary files.**  
-> *type: path*  
-> *default: `/lscratch/$SLURM_JOBID`*
-> 
-> This is a path on the file system for writing temporary output files. By default, the temporary directory is set to '/lscratch/$SLURM_JOBID' for backwards compatibility with the NIH's Biowulf cluster; however, if you are running the pipeline on another cluster, this option will need to be specified. Ideally, this path should point to a dedicated location on the filesystem for writing tmp files. On many systems, this location is set to somewhere in /scratch. If you need to inject a variable into this string that should NOT be expanded, please quote this options value in single quotes. Again, if you are running the pipeline on Biowulf, you do NOT need to provide this option. 
-> 
-> ***Example:*** `--tmp-dir /cluster_scratch/$USER/`
+> _type: path_  
+> _default: `/lscratch/$SLURM_JOBID`_
+>
+> Path on the file system for writing temporary output files. By default, the temporary directory is set to '/lscratch/$SLURM_JOBID' on NIH's Biowulf cluster and 'outdir' on the FRCE cluster. However, if you are running the pipeline on another cluster, this option will need to be specified. Ideally, this path should point to a dedicated location on the filesystem for writing tmp files. On many systems, this location is set to somewhere in /scratch. If you need to inject avariable into this string that should NOT be expanded,please quote this options value in single quotes.
+>
+> **_Example:_** --tmp-dir '/cluster_scratch/$USER/'
 
----  
-  `--threads THREADS`   
+---
+
+`--threads THREADS`
+
 > **Max number of threads for each process.**  
-> *type: int*  
-> *default: 2*
-> 
-> Max number of threads for each process. This option is more applicable when running the pipeline with `--mode local`.  It is recommended setting this vaule to the maximum number of CPUs available on the host machine.
-> 
-> ***Example:*** `--threads 12`
+> _type: int_  
+> _default: 2_
+>
+> Max number of threads for each process. This option is more applicable when running the pipeline with `--mode local`. It is recommended setting this vaule to the maximum number of CPUs available on the host machine.
+>
+> **_Example:_** `--threads 12`
 
 ### 2.4 Misc Options
 
-Each of the following arguments are optional and do not need to be provided. 
+Each of the following arguments are optional and do not need to be provided.
 
-  `-h, --help`            
+`-h, --help`
+
 > **Display Help.**  
-> *type: boolean*
-> 
+> _type: boolean_
+>
 > Shows command's synopsis, help message, and an example command
-> 
-> ***Example:*** `--help`
-
+>
+> **_Example:_** `--help`
 
 ## 3. Example
 
-### 3.1 Biowulf  
+### 3.1 Biowulf
 
-On Biowulf getting started with the pipeline is fast and easy! The pipeline comes bundled with pre-built human and mouse reference genomes. In the example below, we will use the pre-built human reference genome. 
+On Biowulf getting started with the pipeline is fast and easy! The pipeline comes bundled with pre-built human and mouse reference genomes. In the example below, we will use the pre-built human reference genome.
 
-```bash 
+```bash
 # Step 0.) Grab an interactive node (do not run on head node)
 srun -N 1 -n 1 --time=12:00:00 -p interactive --mem=8gb  --cpus-per-task=4 --pty bash
 module purge
@@ -210,9 +232,9 @@ renee run --input .tests/*.R?.fastq.gz \
 
 ### 3.2 Generic SLURM Cluster
 
-Running the pipeline outside of Biowulf is easy; however, there are a few extra steps you must first take. Before getting started, you will need to [build](../TLDR-RNA-seq/#3-building-reference-files) reference files for the pipeline. Please note when running the build sub command for the first time, you will also need to provide the `--shared-resources` option. This option will download our kraken2 database and bowtie2 indices for FastQ Screen. The path provided to this option should be provided to the `--shared-resources` option of the run sub command. Next, you will also need to provide a path to write temporary output files via the `--tmp-dir` option. We also recommend providing a path to a SIF cache. You can cache software containers locally with the [cache](../cache/) sub command. 
+Running the pipeline outside of Biowulf is easy; however, there are a few extra steps you must first take. Before getting started, you will need to [build](../TLDR-RNA-seq/#3-building-reference-files) reference files for the pipeline. Please note when running the build sub command for the first time, you will also need to provide the `--shared-resources` option. This option will download our kraken2 database and bowtie2 indices for FastQ Screen. The path provided to this option should be provided to the `--shared-resources` option of the run sub command. Next, you will also need to provide a path to write temporary output files via the `--tmp-dir` option. We also recommend providing a path to a SIF cache. You can cache software containers locally with the [cache](../cache/) sub command.
 
-```bash 
+```bash
 # Step 0.) Grab an interactive node (do not run on head node)
 srun -N 1 -n 1 --time=2:00:00 -p interactive --mem=8gb  --cpus-per-task=4 --pty bash
 # Add snakemake and singularity to $PATH,

--- a/renee
+++ b/renee
@@ -1757,12 +1757,13 @@ def parsed_arguments(name, description):
           --tmp-dir TMP_DIR
                                 Path on the file system for writing temporary output
                                 files. By default, the temporary directory is set to
-                                '/lscratch/$SLURM_JOBID' for backwards compatibility
-                                with the NIH's Biowulf cluster; however, if you are
-                                running the pipeline on another cluster, this option
-                                will need to be specified. Ideally, this path should
-                                point to a dedicated location on the filesystem for
-                                writing tmp files. On many systems, this location is
+                                '/lscratch/$SLURM_JOBID' on NIH's Biowulf cluster and
+                                'outdir' on the FRCE cluster.
+                                However, if you are running the pipeline on another cluster,
+                                this option will need to be specified.
+                                Ideally, this path should point to a dedicated location on
+                                the filesystem for writing tmp files.
+                                On many systems, this location is
                                 set to somewhere in /scratch. If you need to inject a
                                 variable into this string that should NOT be expanded,
                                 please quote this options value in single quotes.
@@ -2100,17 +2101,18 @@ def parsed_arguments(name, description):
                                 Example: --sif-cache /data/$USER/sifs/
 
           --tmp-dir TMP_DIR
-                              Path on the file system for writing temporary output
-                              files. By default, the temporary directory is set to
-                              '/lscratch/$SLURM_JOBID' for backwards compatibility
-                              with the NIH's Biowulf cluster; however, if you are
-                              running the pipeline on another cluster, this option
-                              will need to be specified. Ideally, this path should
-                              point to a dedicated location on the filesystem for
-                              writing tmp files. On many systems, this location is
-                              set to somewhere in /scratch. If you need to inject a
-                              variable into this string that should NOT be expanded,
-                              please quote this options value in single quotes.
+                            Path on the file system for writing temporary output
+                            files. By default, the temporary directory is set to
+                            '/lscratch/$SLURM_JOBID' on NIH's Biowulf cluster and
+                            'outdir' on the FRCE cluster.
+                            However, if you are running the pipeline on another cluster,
+                            this option will need to be specified.
+                            Ideally, this path should point to a dedicated location on
+                            the filesystem for writing tmp files.
+                            On many systems, this location is
+                            set to somewhere in /scratch. If you need to inject a
+                            variable into this string that should NOT be expanded,
+                            please quote this options value in single quotes.
                                 Example: --tmp-dir '/cluster_scratch/$USER/'
 
           --wait

--- a/renee
+++ b/renee
@@ -45,7 +45,7 @@ except AssertionError:
 
 
 def scontrol_show():
-    """ Run scontrol show config and parse the output as a dictionary
+    """Run scontrol show config and parse the output as a dictionary
     @return scontrol_dict <dict>:
     """
     scontrol_dict = dict()
@@ -61,24 +61,38 @@ def scontrol_show():
 
 
 def get_hpcname():
-    """ Get the HPC name (biowulf, frce, or an empty string)
+    """Get the HPC name (biowulf, frce, or an empty string)
     @return hpcname <str>
     """
     scontrol_out = scontrol_show()
-    hpc = scontrol_out["ClusterName"] if "ClusterName" in scontrol_out.keys() else ''
-    if hpc == 'fnlcr':
-        hpc = 'frce'
+    hpc = scontrol_out["ClusterName"] if "ClusterName" in scontrol_out.keys() else ""
+    if hpc == "fnlcr":
+        hpc = "frce"
     return hpc
 
 
-def get_genomes_list(renee_path, hpcname = get_hpcname()):
-    """ Get list of genome annotations available for the current platform
+def get_tmp_dir(tmp_dir, outdir):
+    """Get default temporary directory for biowulf and frce. Allow user override."""
+    if not tmp_dir:
+        if hpc == "biowulf":
+            tmp_dir = "/lscratch/$SLURM_JOBID"
+        elif hpc == "frce":
+            tmp_dir = outdir
+        else:
+            tmp_dir = None
+    return tmp_dir
+
+
+def get_genomes_list(renee_path, hpcname=get_hpcname()):
+    """Get list of genome annotations available for the current platform
     @return genomes_list <list>
     """
     genome_config_dir = os.path.join(renee_path, "config", "genomes", hpcname)
     json_files = glob.glob(genome_config_dir + "/*.json")
     if not json_files:
-        warnings.warn(f"WARNING: No Genome Annotation JSONs found in {genome_config_dir}. Please specify a custom genome json file with `--genome`")
+        warnings.warn(
+            f"WARNING: No Genome Annotation JSONs found in {genome_config_dir}. Please specify a custom genome json file with `--genome`"
+        )
     genomes = [os.path.basename(file).replace(".json", "") for file in json_files]
     return sorted(genomes)
 
@@ -722,16 +736,20 @@ def setup(sub_args, ifiles, repo_path, output_path):
         "genome": genome_config,
         # Template for tool information
         "tools": os.path.join(output_path, "config", "templates", "tools.json"),
-    }   
+    }
 
     # Global config file for pipeline, config.json
     config = join_jsons(required.values())  # uses templates in the renee repo
     # Update cluster-specific paths for fastq screen & kraken db
-    if hpcname == 'biowulf' or hpcname == 'frce':
-        db_json_filename = os.path.join(output_path, 'config', 'templates', f"dbs_{hpcname}.json")
-        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), db_json_filename), "r") as json_file:
-            config['bin']['rnaseq']['tool_parameters'].update(json.load(json_file))
-
+    if hpcname == "biowulf" or hpcname == "frce":
+        db_json_filename = os.path.join(
+            output_path, "config", "templates", f"dbs_{hpcname}.json"
+        )
+        with open(
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), db_json_filename),
+            "r",
+        ) as json_file:
+            config["bin"]["rnaseq"]["tool_parameters"].update(json.load(json_file))
 
     config = add_user_information(config)
     config = add_rawdata_information(sub_args, config, ifiles)
@@ -864,7 +882,7 @@ def orchestrate(
     threads=2,
     submission_script="runner",
     masterjob="pl:renee",
-    tmp_dir="/lscratch/$SLURM_JOBID/",
+    tmp_dir=None,
     wait="",
     hpcname="",
 ):
@@ -907,6 +925,8 @@ def orchestrate(
     # the container's filesystem, like
     # tmp directories, /lscratch
     addpaths = []
+    # set tmp_dir depending on hpc
+    tmp_dir = get_tmp_dir(tmp_dir, outdir)
     temp = os.path.dirname(tmp_dir.rstrip("/"))
     if temp == os.sep:
         temp = tmp_dir.rstrip("/")
@@ -1084,22 +1104,28 @@ def run(sub_args):
 
     # hpcname is either biowulf, frce, or blank
     hpcname = get_hpcname()
-    if sub_args.runmode == 'init' or not os.path.exists(os.path.join(sub_args.output, 'config.json')):
+    if sub_args.runmode == "init" or not os.path.exists(
+        os.path.join(sub_args.output, "config.json")
+    ):
         # Initialize working directory, copy over required pipeline resources
-        input_files = initialize(sub_args, repo_path=git_repo, output_path=sub_args.output)
+        input_files = initialize(
+            sub_args, repo_path=git_repo, output_path=sub_args.output
+        )
 
         # Step pipeline for execution, create config.json config file from templates
         config = setup(
-            sub_args, ifiles=input_files, repo_path=git_repo, output_path=sub_args.output
+            sub_args,
+            ifiles=input_files,
+            repo_path=git_repo,
+            output_path=sub_args.output,
         )
     # load config from existing file
     else:
         with open(os.path.join(sub_args.output, "config.json"), "r") as config_file:
             config = json.load(config_file)
-        
 
     # ensure the working dir is read/write friendly
-    scripts_path = os.path.join(sub_args.output,'workflow','scripts')
+    scripts_path = os.path.join(sub_args.output, "workflow", "scripts")
     os.chmod(scripts_path, 0o755)
 
     # Optional Step: Dry-run pipeline
@@ -1133,7 +1159,7 @@ def run(sub_args):
         list(config["references"]["rnaseq"].values()) + fq_screen_paths + kraken_db_path
     )
     all_bind_paths = "{},{}".format(",".join(genome_bind_paths), rawdata_bind_paths)
-    
+
     if sub_args.dry_run:  # print singularity bind baths and exit
         print("\nSingularity Bind Paths:{}".format(all_bind_paths))
         sys.exit(0)
@@ -1145,7 +1171,7 @@ def run(sub_args):
         additional_bind_paths=all_bind_paths,
         alt_cache=sub_args.singularity_cache,
         threads=sub_args.threads,
-        tmp_dir=sub_args.tmp_dir,
+        tmp_dir=get_tmp_dir(sub_args.tmp_dir, sub_args.output),
         wait=wait,
         hpcname=hpcname,
     )
@@ -1286,8 +1312,10 @@ def _configure(sub_args, filename, git_repo):
                 fh.write('  {}: "{}"\n'.format(tag, uri))
     print("Done!")
 
+
 def _reset_write_permission(target):
-    os.system("chmod -R u+w,g-w,o-w "+target)
+    os.system("chmod -R u+w,g-w,o-w " + target)
+
 
 def configure_build(sub_args, git_repo, output_path):
     """Setups up working directory for build option and creates config file (build.yml)
@@ -1393,7 +1421,7 @@ def build(sub_args):
         alt_cache=sub_args.singularity_cache,
         submission_script="builder",
         masterjob="pl:build",
-        tmp_dir=sub_args.tmp_dir,
+        tmp_dir=get_tmp_dir(sub_args.tmp_dir, sub_args.output),
         wait=wait,
         hpcname=hpcname,
     )
@@ -1825,9 +1853,7 @@ def parsed_arguments(name, description):
     subparser_run.add_argument(
         "--genome",
         required=True,
-        type=lambda option: str(
-            genome_options(subparser_run, option, GENOMES_LIST)
-        ),
+        type=lambda option: str(genome_options(subparser_run, option, GENOMES_LIST)),
         help=argparse.SUPPRESS,
     )
 
@@ -1865,16 +1891,17 @@ def parsed_arguments(name, description):
         default=False,
         help=argparse.SUPPRESS,
     )
-    subparser_run.add_argument('--runmode',
+    subparser_run.add_argument(
+        "--runmode",
         # Determines how to run the pipeline: init, run
         # TODO: this API is different from XAVIER & CARLISLE, which have a --runmode=dryrun option instead of a --dry-run flag.
-        required = False,
-        default = 'run',
-        choices = ['init','run'],
-        type = str,
-        help = argparse.SUPPRESS
+        required=False,
+        default="run",
+        choices=["init", "run"],
+        type=str,
+        help=argparse.SUPPRESS,
     )
-    
+
     # Execution Method, run locally
     # on a compute node or submit to
     # a supported job scheduler, etc.
@@ -2090,7 +2117,7 @@ def parsed_arguments(name, description):
                                 Wait until master job completes. This is required if
                                 the job is submitted using HPC API. If not provided
                                 the API may interpret submission of master job as
-                                completion of the pipeline!                                
+                                completion of the pipeline!
 
         {1}{2}Misc Options:{4}
           -h, --help          Show usage information, help message, and exit.
@@ -2258,7 +2285,6 @@ def parsed_arguments(name, description):
                                 the API may interpret submission of master job as \
                                 completion of the pipeline!",
     )
-
 
     # Sub-parser for the "unlock" sub-command
     # Grouped sub-parser arguments are currently

--- a/renee
+++ b/renee
@@ -73,6 +73,7 @@ def get_hpcname():
 
 def get_tmp_dir(tmp_dir, outdir):
     """Get default temporary directory for biowulf and frce. Allow user override."""
+    hpc = get_hpcname()
     if not tmp_dir:
         if hpc == "biowulf":
             tmp_dir = "/lscratch/$SLURM_JOBID"

--- a/renee
+++ b/renee
@@ -771,7 +771,7 @@ def setup(sub_args, ifiles, repo_path, output_path):
     config["options"] = {}
     config["options"]["star_2_pass_basic"] = sub_args.star_2_pass_basic
     config["options"]["small_rna"] = sub_args.small_rna
-    config["options"]["tmp_dir"] = sub_args.tmp_dir
+    config["options"]["tmp_dir"] = get_tmp_dir(sub_args.tmp_dir, output_path)
     config["options"]["shared_resources"] = sub_args.shared_resources
     if sub_args.wait:
         config["options"]["wait"] = "True"

--- a/renee
+++ b/renee
@@ -1977,7 +1977,7 @@ def parsed_arguments(name, description):
         "--tmp-dir",
         type=str,
         required=False,
-        default="/lscratch/$SLURM_JOBID/",
+        default="",
         help=argparse.SUPPRESS,
     )
 

--- a/renee
+++ b/renee
@@ -1758,7 +1758,7 @@ def parsed_arguments(name, description):
                                 Path on the file system for writing temporary output
                                 files. By default, the temporary directory is set to
                                 '/lscratch/$SLURM_JOBID' on NIH's Biowulf cluster and
-                                'outdir' on the FRCE cluster.
+                                'OUTPUT' on the FRCE cluster.
                                 However, if you are running the pipeline on another cluster,
                                 this option will need to be specified.
                                 Ideally, this path should point to a dedicated location on


### PR DESCRIPTION
## Changes

Automatically set it to `lscratch/$SLURM_JOBID` on biowulf or the `OUTPUT` argument on FRCE.
Still allow users to override the default by setting `--tmp-dir` on the CLI.

## Issues

- Fixes #79

## Testing

- [x] biowulf
- [x] frce

without tmp-dir flag on either platform

```sh
#!/usr/bin/env bash
RENEE_DIR=/mnt/projects/CCBR-Pipelines/pipelines/RENEE/renee-dev-sovacool
WORKDIR=/scratch/cluster_scratch/$USER/renee_test_v2.5.11
rm -rf $WORKDIR

module load singularity
$RENEE_DIR/bin/renee run \
	--input $RENEE_DIR/.tests/*.R?.fastq.gz \
	--output $WORKDIR \
	--genome hg38_30 \
	--mode slurm \
	--sif-cache /mnt/projects/CCBR-Pipelines/SIFs
```

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
