### PR TITLE
fix: run renee even if snakemake/singularity not in path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## RENEE development version
+
 - Fix: RNA report bug, caused by hard-coding of PC1-3, when only PC1-2 were generated (#104, @slsevilla)
 - Minor documentation improvements. (#100, @kelly-sovacool)
+- Fix: allow printing the version or help message even if singularity is not in the path. (#110, @kelly-sovacool)
 
 ## RENEE 2.5.11
 

--- a/bin/redirect
+++ b/bin/redirect
@@ -67,13 +67,4 @@ elif [[ $ISFRCE == true ]];then
 	export PATH="/mnt/projects/CCBR-Pipelines/bin:$PATH"
 fi
 
-# check if singularity, snakemake are in PATH
-for tool in singularity snakemake;do
-	x=$(type -P $tool)
-	if [[ -z $x ]]; then # is $x blank
-		echo "$tool is not it path! Exiting."
-		exit
-	fi
-done
-
 ${TOOLDIR}/${TOOLNAME} "$@" || true


### PR DESCRIPTION
## Changes

This is a quick bandaid fix for #107. A more robust fix would involve reimplementing a lot of the CLI, and that is not worth it now when we are going to do so anyway when we switch to nextflow.


## Issues

- mostly fixes #107 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
