### PR TITLE
test: setup basic cli tests with pytest

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,12 +12,12 @@ jobs:
   Dryrun_Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: docker://snakemake/snakemake:v5.24.2
       - name: Dry-run pipeline
         run: |
           docker run -v $PWD:/opt2 -w /opt2 snakemake/snakemake:v5.24.2 \
-            python ./renee run \
+            python ./renee.py run \
               --input .tests/KO_S3.R1.fastq.gz .tests/KO_S3.R2.fastq.gz .tests/KO_S4.R1.fastq.gz .tests/KO_S4.R2.fastq.gz .tests/WT_S1.R1.fastq.gz .tests/WT_S1.R2.fastq.gz .tests/WT_S2.R1.fastq.gz .tests/WT_S2.R2.fastq.gz \
               --output output \
               --genome config/genomes/biowulf/hg38_30.json \
@@ -29,3 +29,38 @@ jobs:
         run: |
           docker run -v $PWD:/opt2 snakemake/snakemake:v5.24.2 snakemake --lint -s /opt2/output/workflow/Snakefile -d /opt2/output || \
           echo 'There may have been a few warnings or errors. Please read through the log to determine if its harmless.'
+
+  Test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: pip
+        run: |
+          python -m pip install --upgrade pip setuptools pytest
+      - name: check CLI basics
+        run: |
+          ./bin/renee --help
+          ./bin/renee --version
+      - name: Test
+        run: |
+          python -m pytest
+
+  build-status: # https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
+    runs-on: ubuntu-latest
+    needs: [Dryrun_Lint, Test]
+    if: always()
+    steps:
+      - name: Successful build
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Failing build
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Dry-run pipeline
         run: |
           docker run -v $PWD:/opt2 -w /opt2 snakemake/snakemake:v5.24.2 \
-            python ./renee.py run \
+            python ./src/renee/__main__.py run \
               --input .tests/KO_S3.R1.fastq.gz .tests/KO_S3.R2.fastq.gz .tests/KO_S4.R1.fastq.gz .tests/KO_S4.R2.fastq.gz .tests/WT_S1.R1.fastq.gz .tests/WT_S1.R2.fastq.gz .tests/WT_S2.R1.fastq.gz .tests/WT_S2.R2.fastq.gz \
               --output output \
               --genome config/genomes/biowulf/hg38_30.json \

--- a/bin/redirect
+++ b/bin/redirect
@@ -67,4 +67,4 @@ elif [[ $ISFRCE == true ]];then
 	export PATH="/mnt/projects/CCBR-Pipelines/bin:$PATH"
 fi
 
-${TOOLDIR}/${TOOLNAME} "$@" || true
+${TOOLDIR}/src/renee/__main__.py "$@" || true

--- a/src/renee/__main__.py
+++ b/src/renee/__main__.py
@@ -1104,7 +1104,6 @@ def run(sub_args):
         Parsed arguments for run sub-command
     """
     # Get PATH to RENEE git repository for copying over pipeline resources
-    git_repo = os.path.dirname(os.path.abspath(__file__))
 
     # hpcname is either biowulf, frce, or blank
     hpcname = get_hpcname()
@@ -1113,14 +1112,14 @@ def run(sub_args):
     ):
         # Initialize working directory, copy over required pipeline resources
         input_files = initialize(
-            sub_args, repo_path=git_repo, output_path=sub_args.output
+            sub_args, repo_path=RENEE_PATH, output_path=sub_args.output
         )
 
         # Step pipeline for execution, create config.json config file from templates
         config = setup(
             sub_args,
             ifiles=input_files,
-            repo_path=git_repo,
+            repo_path=RENEE_PATH,
             output_path=sub_args.output,
         )
     # load config from existing file
@@ -1373,7 +1372,6 @@ def build(sub_args):
     """
     # Get PATH to RENEE git repository
     # for copying over pipeline resources
-    git_repo = os.path.dirname(os.path.abspath(__file__))
 
     # Build Output directory
     output_path = os.path.abspath(sub_args.output)
@@ -1382,7 +1380,7 @@ def build(sub_args):
     # initialize, copy resources, and
     # generate config file
     additional_bind_paths = configure_build(
-        sub_args=sub_args, git_repo=git_repo, output_path=output_path
+        sub_args=sub_args, git_repo=RENEE_PATH, output_path=output_path
     )
 
     # Add any additional bindpaths

--- a/src/renee/__main__.py
+++ b/src/renee/__main__.py
@@ -25,7 +25,10 @@ import argparse  # potential python3 3rd party package, added in python/3.5
 
 # Pipeline Metadata and globals
 # __version__ = "v2.5.2"
-RENEE_PATH = os.path.dirname(os.path.abspath(__file__))
+RENEE_PATH = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+
 vfile = open(os.path.join(RENEE_PATH, "VERSION"), "r")
 __version__ = "v" + vfile.read()
 __version__ = __version__.strip()
@@ -1588,7 +1591,7 @@ def parsed_arguments(name, description):
 
     # Adding Version information
     parser.add_argument(
-        "--version", action="version", version="%(prog)s {}".format(__version__)
+        "--version", action="version", version="renee {}".format(__version__)
     )
 
     # Create sub-command parser

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+import pytest
+import subprocess
+from src.renee.__main__ import exists
+
+
+def test_help():
+    output = subprocess.run(
+        "src/renee/__main__.py --help", capture_output=True, shell=True, text=True
+    ).stdout
+    assert "RENEE" in output
+
+
+def test_version():
+    output = subprocess.run(
+        "src/renee/__main__.py --version", capture_output=True, shell=True, text=True
+    ).stdout
+    assert "renee v" in output


### PR DESCRIPTION
## Changes

- move `renee` script to `src/renee/__main__.py`, which effectively makes it a python package for compatibility with pytest.
- `bin/redirect` (symlinked to `bin/renee`) now calls `src/renee/__main__.py`, so the interface won't be any different for users.
- new `tests` directory for pytest.
- created basic tests for help & version CLI options.

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

<!--
**Reviewers**: Use the @ feature to mention anyone responsible for reviewing/completing this request.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
