### PR TITLE
test: show that sif images are cached correctly

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,6 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: test
-          micromamba-version: "1.3.1-0"
           cache-environment: true
           create-args: |
             python=${{ matrix.python-version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,6 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           micromamba-version: "1.3.1-0"
-          cache-environment: true
           create-args: |
             python=${{ matrix.python-version }}
             snakemake=${{ matrix.snakemake-version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,6 +52,8 @@ jobs:
       - name: Test
         run: |
           python -m pytest
+        env:
+          TMPDIR: ${{ runner.temp }}
 
   build-status: # https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Dry-run pipeline
         run: |
           docker run -v $PWD:/opt2 -w /opt2 snakemake/snakemake:v5.24.2 \
-            python ./renee.py run \
+            python src/renee/__main__.py run \
               --input .tests/KO_S3.R1.fastq.gz .tests/KO_S3.R2.fastq.gz .tests/KO_S4.R1.fastq.gz .tests/KO_S4.R2.fastq.gz .tests/WT_S1.R1.fastq.gz .tests/WT_S1.R2.fastq.gz .tests/WT_S2.R1.fastq.gz .tests/WT_S2.R2.fastq.gz \
               --output output \
               --genome config/genomes/biowulf/hg38_30.json \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,23 +37,31 @@ jobs:
         python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
+          micromamba-version: "1.3.1-0"
+          cache-environment: true
+          create-args: |
+            python=${{ matrix.python-version }}
+            snakemake
+            setuptools
+            pip
+            pytest
       - name: pip
         run: |
-          python -m pip install --upgrade pip setuptools pytest
+          python -m pip install
+        shell: micromamba-shell {0}
       - name: check CLI basics
         run: |
           ./bin/renee --help
           ./bin/renee --version
+        shell: micromamba-shell {0}
       - name: Test
         run: |
           python -m pytest
         env:
           TMPDIR: ${{ runner.temp }}
+        shell: micromamba-shell {0}
 
   build-status: # https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        python-version: ["3.11"]
         snakemake-version: ["7.32.3"]
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +42,8 @@ jobs:
         with:
           environment-name: test
           cache-environment: true
-          create-args: |
+          create-args: >-
+            python=${{ matrix.python-version }}
             snakemake=${{ matrix.snakemake-version }}
             setuptools
             pip

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
         with:
+          environment-name: test
           micromamba-version: "1.3.1-0"
+          cache-environment: true
           create-args: |
             python=${{ matrix.python-version }}
             snakemake=${{ matrix.snakemake-version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,10 +52,6 @@ jobs:
             setuptools
             pip
             pytest
-      - name: pip
-        run: |
-          python -m pip install
-        shell: micromamba-shell {0}
       - name: check CLI basics
         run: |
           ./bin/renee --help

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,6 +42,10 @@ jobs:
         with:
           environment-name: test
           cache-environment: true
+          condarc: |
+            channels:
+              - conda-forge
+              - bioconda
           create-args: >-
             python=${{ matrix.python-version }}
             snakemake=${{ matrix.snakemake-version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,6 +35,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
+        snakemake-version: ["7.32.3"]
     steps:
       - uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
@@ -43,7 +44,7 @@ jobs:
           cache-environment: true
           create-args: |
             python=${{ matrix.python-version }}
-            snakemake
+            snakemake=${{ matrix.snakemake-version }}
             setuptools
             pip
             pytest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,7 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
         snakemake-version: ["7.32.3"]
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +42,6 @@ jobs:
           environment-name: test
           cache-environment: true
           create-args: |
-            python=${{ matrix.python-version }}
             snakemake=${{ matrix.snakemake-version }}
             setuptools
             pip

--- a/src/renee/__main__.py
+++ b/src/renee/__main__.py
@@ -812,7 +812,6 @@ def setup(sub_args, ifiles, repo_path, output_path):
         ),
         end="",
     )
-    # print(json.dumps(config, indent = 4, sort_keys=True))
     with open(os.path.join(output_path, "config.json"), "w") as fh:
         json.dump(config, fh, indent=4, sort_keys=True)
     print("Done!")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,45 @@
+import tempfile
+import json
+import os.path
+import subprocess
+
+renee_run = (
+    "src/renee/__main__.py run "
+    "--mode local --runmode init --dry-run "
+    "--input .tests/*.fastq.gz "
+    "--genome hg38_30 "
+)
+
+
+def run_in_temp(command_str):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        outdir = os.path.join(tmp_dir, "testout")
+        output = subprocess.run(
+            f"{command_str} --output {outdir}",
+            capture_output=True,
+            shell=True,
+            text=True,
+        )
+        with open(os.path.join(outdir, "config.json"), "r") as infile:
+            config = json.load(infile)
+    return output, config
+
+
+def test_cache_sif():
+    output, config = run_in_temp(f"{renee_run} --sif-cache tests/data/sifs/")
+    assertions = [
+        config["images"]["arriba"].endswith(
+            "tests/data/sifs/ccbr_arriba_2.0.0_v0.0.1.sif"
+        ),
+        "does not exist in singularity cache" in output.stderr,
+    ]
+    assert all(assertions)
+
+
+def test_cache_nosif():
+    output, config = run_in_temp(f"{renee_run}")
+    assertions = [
+        config["images"]["arriba"] == "docker://nciccbr/ccbr_arriba_2.0.0:v0.0.1",
+        "The singularity command has to be available" in output.stderr,
+    ]
+    assert all(assertions)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,7 +7,7 @@ renee_run = (
     "src/renee/__main__.py run "
     "--mode local --runmode init --dry-run "
     "--input .tests/*.fastq.gz "
-    "--genome hg38_30 "
+    "--genome config/genomes/biowulf/hg38_30.json "
 )
 
 
@@ -20,8 +20,11 @@ def run_in_temp(command_str):
             shell=True,
             text=True,
         )
-        with open(os.path.join(outdir, "config.json"), "r") as infile:
-            config = json.load(infile)
+        if os.path.exists(os.path.join(outdir, "config.json")):
+            with open(os.path.join(outdir, "config.json"), "r") as infile:
+                config = json.load(infile)
+        else:
+            config = None
     return output, config
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ renee_run = (
     "src/renee/__main__.py run "
     "--mode local --runmode init --dry-run "
     "--input .tests/*.fastq.gz "
-    "--genome hg38_30 "
+    "--genome config/genomes/biowulf/hg38_30.json "
 )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,12 @@
 import pytest
 import subprocess
-from src.renee.__main__ import exists
+
+renee_run = (
+    "src/renee/__main__.py run "
+    "--mode local --runmode init --dry-run "
+    "--input .tests/*.fastq.gz "
+    "--genome hg38_30 "
+)
 
 
 def test_help():
@@ -15,3 +21,12 @@ def test_version():
         "src/renee/__main__.py --version", capture_output=True, shell=True, text=True
     ).stdout
     assert "renee v" in output
+
+
+def test_run_error():
+    assert (
+        "the following arguments are required: --output"
+        in subprocess.run(
+            f"{renee_run}", capture_output=True, shell=True, text=True
+        ).stderr
+    )


### PR DESCRIPTION
## Changes

Create unit tests proving that the sif images are handled correctly.
When `--sif-cache` is used, the config file has the sifs pointing to the sif file paths. Otherwise, it contains docker URLs.

This PR adds unit tests and modifies the github action, but does not modify the actual code base.

Merge #114 before this PR

## Issues

Resolves #113 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
