### PR TITLE
feat: add hg38 v45 reference genome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## RENEE development version
 
+- Support hg38 release 45 on biowulf & FRCE. (#127, @kelly-sovacool)
+
 ## RENEE 2.5.12
 
 - Minor documentation improvements. (#100, @kelly-sovacool)

--- a/config/genomes/biowulf/hg38_45.json
+++ b/config/genomes/biowulf/hg38_45.json
@@ -1,0 +1,25 @@
+{
+    "references": {
+        "rnaseq": {
+            "GENOMEFILE": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/GRCh38.primary_assembly.genome.fa",
+            "GENOME": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/GRCh38.primary_assembly.genome.fa",
+            "GTFFILE": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/gencode.v45.primary_assembly.annotation.gtf",
+            "GENOME_STARDIR": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/STAR/2.7.6a/genome",
+            "ANNOTATE": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/annotate.genes.txt",
+            "ANNOTATEISOFORMS": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/annotate.isoforms.txt",
+            "REFFLAT": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/refFlat.txt",
+            "BEDREF": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/genes.ref.bed",
+            "GENEINFO": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/geneinfo.bed",
+            "QUALIMAP_INFO": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/qualimap_info.txt",
+            "KARYOBEDS": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/karyobeds/",
+            "KARYOPLOTER": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/karyoplot_gene_coordinates.txt",
+            "RSEMREF": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/rsemref/hg38_45",
+            "RRNALIST": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/hg38_45.rRNA_interval_list",
+            "ORGANISM": "hg38",
+            "TINREF": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/transcripts.protein_coding_only.bed12",
+            "FUSIONBLACKLIST": "s3://nciccbr/Resources/RNA-seq/arriba/blacklist_hg38_GRCh38_v2.0.0.tsv.gz",
+            "FUSIONCYTOBAND": "s3://nciccbr/Resources/RNA-seq/arriba/cytobands_hg38_GRCh38_v2.0.0.tsv",
+            "FUSIONPROTDOMAIN": "s3://nciccbr/Resources/RNA-seq/arriba/protein_domains_hg38_GRCh38_v2.0.0.gff3"
+        }
+    }
+}

--- a/config/genomes/biowulf/hg38_45.json
+++ b/config/genomes/biowulf/hg38_45.json
@@ -1,8 +1,8 @@
 {
     "references": {
         "rnaseq": {
-            "GENOMEFILE": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/GRCh38.primary_assembly.genome.fa",
-            "GENOME": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/GRCh38.primary_assembly.genome.fa",
+            "GENOMEFILE": "/data/CCBR_Pipeliner/Pipelines/RENEE/resources/fastas/GRCh38.primary_assembly.genome.fa",
+            "GENOME": "/data/CCBR_Pipeliner/Pipelines/RENEE/resources/fastas/GRCh38.primary_assembly.genome.fa",
             "GTFFILE": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/gencode.v45.primary_assembly.annotation.gtf",
             "GENOME_STARDIR": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/STAR/2.7.6a/genome",
             "ANNOTATE": "/data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45/annotate.genes.txt",

--- a/config/genomes/frce/hg38_45.json
+++ b/config/genomes/frce/hg38_45.json
@@ -1,0 +1,25 @@
+{
+    "references": {
+        "rnaseq": {
+            "GENOMEFILE": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/GRCh38.primary_assembly.genome.fa",
+            "GENOME": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/GRCh38.primary_assembly.genome.fa",
+            "GTFFILE": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/gencode.v45.primary_assembly.annotation.gtf",
+            "GENOME_STARDIR": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/STAR/2.7.6a/genome",
+            "ANNOTATE": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/annotate.genes.txt",
+            "ANNOTATEISOFORMS": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/annotate.isoforms.txt",
+            "REFFLAT": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/refFlat.txt",
+            "BEDREF": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/genes.ref.bed",
+            "GENEINFO": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/geneinfo.bed",
+            "QUALIMAP_INFO": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/qualimap_info.txt",
+            "KARYOBEDS": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/karyobeds/",
+            "KARYOPLOTER": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/karyoplot_gene_coordinates.txt",
+            "RSEMREF": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/rsemref/hg38_45",
+            "RRNALIST": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/hg38_45.rRNA_interval_list",
+            "ORGANISM": "hg38",
+            "TINREF": "/mnt/projects/CCBR-Pipelines/genomes/hg38_45/transcripts.protein_coding_only.bed12",
+            "FUSIONBLACKLIST": "s3://nciccbr/Resources/RNA-seq/arriba/blacklist_hg38_GRCh38_v2.0.0.tsv.gz",
+            "FUSIONCYTOBAND": "s3://nciccbr/Resources/RNA-seq/arriba/cytobands_hg38_GRCh38_v2.0.0.tsv",
+            "FUSIONPROTDOMAIN": "s3://nciccbr/Resources/RNA-seq/arriba/protein_domains_hg38_GRCh38_v2.0.0.gff3"
+        }
+    }
+}

--- a/config/templates/tools.json
+++ b/config/templates/tools.json
@@ -32,7 +32,7 @@
                 "FASTAWITHADAPTERSETD": "resources/TruSeq_and_nextera_adapters.consolidated.fa",
                 "FASTQ_SCREEN_CONFIG": "resources/fastq_screen.conf",
                 "FASTQ_SCREEN_CONFIG2": "resources/fastq_screen_2.conf",
-                "KRAKENBACDB": "/data/CCBR_Pipeliner/Pipelines/RENEE/resources/shared_resources/20180907_standard_kraken2",
+                "KRAKENBACDB": "shared_resources/20180907_standard_kraken2",
                 "Trimsettings": "---------------------------- TRIMMOMATIC parameters ----------------------------------------------------------",
                 "LEADINGQUALITY": 10,
                 "TRAILINGQUALITY": 10,

--- a/docs/RNA-seq/Resources.md
+++ b/docs/RNA-seq/Resources.md
@@ -14,6 +14,7 @@ Bundled Biowulf Reference Genomes
 | hg38_34    | Homo sapiens (human) | [Gencode Release v34](https://www.gencodegenes.org/human/release_34.html)  | [GRCh38](https://www.gencodegenes.org/human/release_34.html), Annotation Release date: 04/2020  |
 | hg38_38    | Homo sapiens (human) | [Gencode Release v38](https://www.gencodegenes.org/human/release_38.html)  | [GRCh38](https://www.gencodegenes.org/human/release_38.html), Annotation Release date: 05/2021  |
 | hg38_41    | Homo sapiens (human) | [Gencode Release v41](https://www.gencodegenes.org/human/release_41.html)  | [GRCh38](https://www.gencodegenes.org/human/release_41.html), Annotation Release date: 07/2022  |
+| hg38_45    | Homo sapiens (human) | [Gencode Release v45](https://www.gencodegenes.org/human/release_45.html)  | [GRCh38](https://www.gencodegenes.org/human/release_45.html), Annotation Release date: 03/2023  |
 | mm10_M21   | Mus musculus (mouse) | [Gencode Release M21](https://www.gencodegenes.org/mouse/release_M21.html) | [GRCm38](https://www.gencodegenes.org/mouse/release_M21.html), Annotation Release date: 04/2019 |
 | mm10_M23   | Mus musculus (mouse) | [Gencode Release M23](https://www.gencodegenes.org/mouse/release_M23.html) | [GRCm38](https://www.gencodegenes.org/mouse/release_M23.html), Annotation Release date: 09/2019 |
 | mm10_M25   | Mus musculus (mouse) | [Gencode Release M25](https://www.gencodegenes.org/mouse/release_M25.html) | [GRCm38](https://www.gencodegenes.org/mouse/release_M25.html), Annotation Release date: 04/2020 |


### PR DESCRIPTION
## Changes

Adds configuration files for gencode release 45 of hg38.


### Steps

Using PRI regions

- source: https://www.gencodegenes.org/human/
- gtf: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_45/gencode.v45.primary_assembly.annotation.gtf.gz
- fasta: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_45/GRCh38.primary_assembly.genome.fa.gz

#### build command

```sh
renee build \
    --sif-cache /data/CCBR_Pipeliner/SIFS \
    --ref-fa GRCh38.primary_assembly.genome.fa \
    --ref-name hg38 \
    --ref-gtf gencode.v45.primary_assembly.annotation.gtf \
    --gtf-ver 45 \
    --output /data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45
```

#### change ownership

```sh
chown -R :CCBR_Pipeliner /data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45
chmod -R a+rX /data/CCBR_Pipeliner/db/PipeDB/Indices/hg38_45
```

## testing

### biowulf ✅

```sh
/data/CCBR_Pipeliner/Pipelines/RENEE/renee-dev-sovacool/bin/renee run \
    --input /data/CCBR_Pipeliner/Pipelines/RENEE/develop/.tests/*.R1.fastq.gz \
    --genome hg38_45 \
    --mode slurm \
    --output /data/$USER/renee_test_gencode-45 \
    --sif-cache /data/CCBR_Pipeliner/SIFS

```

### frce [in progress]

```sh
/mnt/projects/CCBR-Pipelines/pipelines/RENEE/renee-dev-sovacool/bin/renee run \
	--input latest/.tests/*.R?.fastq.gz \
	--output /scratch/cluster_scratch/$USER/renee_test_gencode-45 \
	--genome hg38_45 \
	--mode slurm \
	--tmp-dir /scratch/cluster_scratch/$USER \
	--sif-cache /mnt/projects/CCBR-Pipelines/SIFs
```

## Issues

Resolves #126 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
