### PR TITLE
fix: show renee <subcommand> for help messages rather than python script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Minor documentation improvements. (#100, @kelly-sovacool)
 - Fix RNA report bug, caused by hard-coding of PC1-3, when only PC1-2 were generated. (#104, @slsevilla)
-- Allow printing the version or help message even if singularity is not in the path. (#110, @kelly-sovacool)
+- Improvements to the CLI:
+  - Allow printing the version or help message even if singularity is not in the path. (#110, @kelly-sovacool)
+  - Show the name of the pipeline rather than the python script for CLI help messages. (#131, @kelly-sovacool)
 - Fix RSeQC environments:
   - Set RSeQC envmodule version to 4.0.0, which synchronizes it with the version in the docker container used by singularity. (#122, @kelly-sovacool)
   - Update docker with RSeQC's tools properly added to the path. (#123, @kelly-sovacool)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## RENEE development version
 
+- Show the name of the pipeline rather than the python script for CLI help messages. (#131, @kelly-sovacool)
+
 ## RENEE 2.5.12
 
 - Minor documentation improvements. (#100, @kelly-sovacool)
 - Fix RNA report bug, caused by hard-coding of PC1-3, when only PC1-2 were generated. (#104, @slsevilla)
-- Improvements to the CLI:
-  - Allow printing the version or help message even if singularity is not in the path. (#110, @kelly-sovacool)
-  - Show the name of the pipeline rather than the python script for CLI help messages. (#131, @kelly-sovacool)
+- Allow printing the version or help message even if singularity is not in the path. (#110, @kelly-sovacool)
 - Fix RSeQC environments:
   - Set RSeQC envmodule version to 4.0.0, which synchronizes it with the version in the docker container used by singularity. (#122, @kelly-sovacool)
   - Update docker with RSeQC's tools properly added to the path. (#123, @kelly-sovacool)

--- a/src/renee/__main__.py
+++ b/src/renee/__main__.py
@@ -1187,10 +1187,12 @@ def run(sub_args):
     # pipeline that ran in local mode
     if sub_args.mode == "local":
         if int(masterjob.returncode) == 0:
-            print("{} pipeline has successfully completed".format(_name))
+            print("{} pipeline has successfully completed".format("RENEE"))
         else:
             fatal(
-                "{} pipeline failed. Please see standard output for more information."
+                "{} pipeline failed. Please see standard output for more information.".format(
+                    "RENEE"
+                )
             )
     elif sub_args.mode == "slurm":
         jobid = (
@@ -1435,10 +1437,12 @@ def build(sub_args):
     sub_args.mode = "slurm"
     if sub_args.mode == "local":
         if int(masterjob.returncode) == 0:
-            print("{} pipeline has successfully completed".format(_name))
+            print("{} pipeline has successfully completed".format("RENEE"))
         else:
             fatal(
-                "{} pipeline failed. Please see standard output for more information."
+                "{} pipeline failed. Please see standard output for more information.".format(
+                    "RENEE"
+                )
             )
     elif sub_args.mode == "slurm":
         jobid = (
@@ -1779,7 +1783,7 @@ def parsed_arguments(name, description):
           -h, --help            Show usage information, help message, and exit.
                                   Example: --help
         """.format(
-            name, c.bold, c.url, c.italic, c.end
+            "renee", c.bold, c.url, c.italic, c.end
         )
     )
 
@@ -1815,7 +1819,7 @@ def parsed_arguments(name, description):
         {2}{3}Prebuilt genome+annotation combos:{4}
           {5}
         """.format(
-            name, __version__, c.bold, c.url, c.end, list(GENOMES_LIST)
+            "renee", __version__, c.bold, c.url, c.end, list(GENOMES_LIST)
         )
     )
 
@@ -2126,7 +2130,7 @@ def parsed_arguments(name, description):
           -h, --help          Show usage information, help message, and exit.
                                 Example: --help
         """.format(
-            name, c.bold, c.url, c.italic, c.end
+            "renee", c.bold, c.url, c.italic, c.end
         )
     )
 
@@ -2162,7 +2166,7 @@ def parsed_arguments(name, description):
         {2}{3}Prebuilt genome+annotation combos:{4}
           {5}
         """.format(
-            name, __version__, c.bold, c.url, c.end, list(GENOMES_LIST)
+            "renee", __version__, c.bold, c.url, c.end, list(GENOMES_LIST)
         )
     )
 
@@ -2326,7 +2330,7 @@ def parsed_arguments(name, description):
           -h, --help            Show usage information and exit.
                                   Example: --help
         """.format(
-            name, c.bold, c.url, c.italic, c.end
+            "renee", c.bold, c.url, c.italic, c.end
         )
     )
 
@@ -2347,7 +2351,7 @@ def parsed_arguments(name, description):
         {2}{3}Version:{4}
           {1}
         """.format(
-            name, __version__, c.bold, c.url, c.end
+            "renee", __version__, c.bold, c.url, c.end
         )
     )
 
@@ -2382,7 +2386,7 @@ def parsed_arguments(name, description):
         {1}{0} {3}cache{4}: {1}Cache software containers locally.{4}
 
         {1}{2}Synopsis:{4}
-          $ {0} cache [-h] [--dry-run] \\
+          $ {0} cache [--help] [--dry-run] \\
                   --sif-cache SIF_CACHE
 
         {1}{2}Description:{4}
@@ -2420,7 +2424,7 @@ def parsed_arguments(name, description):
           -h, --help            Show usage information and exits.
                                   Example: --help
         """.format(
-            name, c.bold, c.url, c.italic, c.end
+            "renee", c.bold, c.url, c.italic, c.end
         )
     )
 
@@ -2447,7 +2451,7 @@ def parsed_arguments(name, description):
         {2}Version:{3}
           {1}
         """.format(
-            name, __version__, c.bold, c.end
+            "renee", __version__, c.bold, c.end
         )
     )
 
@@ -2500,7 +2504,7 @@ def main():
     # Sanity check for usage
     if len(sys.argv) == 1:
         # Nothing was provided
-        fatal("Invalid usage: {} [-h] [--version] ...".format(_name))
+        fatal("Invalid usage: {} [-h] [--version] ...".format("renee"))
 
     # Collect args for sub-command
     args = parsed_arguments(name=_name, description=_description)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,3 +30,18 @@ def test_run_error():
             f"{renee_run}", capture_output=True, shell=True, text=True
         ).stderr
     )
+
+
+def test_subcommands_help():
+    assert all(
+        [
+            f"renee {cmd } [--help]"
+            in subprocess.run(
+                f"src/renee/__main__.py {cmd} --help",
+                capture_output=True,
+                shell=True,
+                text=True,
+            ).stdout
+            for cmd in ["run", "build", "cache", "unlock"]
+        ]
+    )


### PR DESCRIPTION
## Changes

This bug was introduced in #114, which renamed the main python script to allow compatibility with unit tests. A number of CLI print messages used the name of the python script (which used to be `renee` but is now `__main__.py`) rather than the name of the pipeline.

## Issues

fixes #130

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
