### PR TITLE
docs: suggest --sif-cache in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## RENEE development version
 
+- Minor documentation improvements. (#132, @kelly-sovacool)
+
 ## RENEE 2.5.12
 
 - Minor documentation improvements. (#100, @kelly-sovacool)

--- a/README.md
+++ b/README.md
@@ -121,9 +121,15 @@ renee run --input .tests/*.R?.fastq.gz --output /data/$USER/RNA_hg38 --genome hg
 
 # @slurm: uses slurm and singularity execution method
 # The slurm MODE will submit jobs to the cluster.
+# The --sif-cache flag will re-use singularity containers from a shared location.
 # It is recommended running RENEE in this mode.
 module load ccbrpipeliner
-renee run --input .tests/*.R?.fastq.gz --output /data/$USER/RNA_hg38 --genome hg38_30 --mode slurm
+renee run \
+  --input .tests/*.R?.fastq.gz \
+  --output /data/$USER/RNA_hg38 \
+  --genome hg38_30 \
+  --mode slurm \
+  --sif-cache /data/CCBR_Pipeliner/SIFS
 ```
 
 #### 3.2 FRCE
@@ -137,6 +143,19 @@ srun --export all --pty --x11 bash
 
 # run renee
 renee --help
+```
+
+When running renee on FRCE, we recommend setting `--tmp-dir` and `--sif-cache`
+with the following values:
+
+```sh
+renee run \
+  --input .tests/*.R?.fastq.gz \
+  --output /scratch/cluster_scratch/$USER/RNA_hg38 \
+  --genome hg38_30 \
+  --mode slurm \
+  --tmp-dir /scratch/cluster_scratch/$USER \
+  --sif-cache /mnt/projects/CCBR-Pipelines/SIFs
 ```
 
 <hr>


### PR DESCRIPTION
## Changes

Add recommended `--sif-cache` usage for biowulf and FRCE. Many of our users get started from the readme file and never see this option buried in the docs, but it's very helpful to avoid needing to download containers.

Based on feedback from @TJoshMeyer

## Issues

resolves #132 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
