### PR TITLE
fix copy in safe mode

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,12 +9,12 @@ on:
   pull_request:
 
 jobs:
-  Dryrun_Lint:
+  dryrun-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: docker://snakemake/snakemake:v7.32.4
-      - name: Dry-run pipeline
+      - name: Dry-run
         run: |
           docker run -v $PWD:/opt2 -w /opt2 snakemake/snakemake:v7.32.4 \
             ./bin/renee run \
@@ -24,10 +24,11 @@ jobs:
               --shared-resources .tests/shared_resources/ \
               --mode local \
               --dry-run
-      - name: Lint workflow
+      - name: Lint
         continue-on-error: true
         run: |
-          docker run -v $PWD:/opt2 snakemake/snakemake:v5.24.2 snakemake --lint -s /opt2/output/workflow/Snakefile -d /opt2/output || \
+          docker run -v $PWD:/opt2 snakemake/snakemake:v7.32.4 \
+            snakemake --lint -s /opt2/output/workflow/Snakefile -d /opt2/output || \
           echo 'There may have been a few warnings or errors. Please read through the log to determine if its harmless.'
 
   Test:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,6 +57,10 @@ jobs:
           ./bin/renee --help
           ./bin/renee --version
         shell: micromamba-shell {0}
+      - name: pip install python package
+        run: |
+          pip install .[dev,test]
+        shell: micromamba-shell {0}
       - name: Test
         run: |
           python -m pytest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Dry-run pipeline
         run: |
           docker run -v $PWD:/opt2 -w /opt2 snakemake/snakemake:v7.32.4 \
-            python src/renee/__main__.py run \
+            ./bin/renee run \
               --input .tests/KO_S3.R1.fastq.gz .tests/KO_S3.R2.fastq.gz .tests/KO_S4.R1.fastq.gz .tests/KO_S4.R2.fastq.gz .tests/WT_S1.R1.fastq.gz .tests/WT_S1.R2.fastq.gz .tests/WT_S2.R1.fastq.gz .tests/WT_S2.R2.fastq.gz \
               --output output \
               --genome config/genomes/biowulf/hg38_30.json \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: docker://snakemake/snakemake:v7.32.4
       - name: Dry-run pipeline
         run: |
-          docker run -v $PWD:/opt2 -w /opt2 snakemake/snakemake:v5.24.2 \
+          docker run -v $PWD:/opt2 -w /opt2 snakemake/snakemake:v7.32.4 \
             python src/renee/__main__.py run \
               --input .tests/KO_S3.R1.fastq.gz .tests/KO_S3.R2.fastq.gz .tests/KO_S4.R1.fastq.gz .tests/KO_S4.R2.fastq.gz .tests/WT_S1.R1.fastq.gz .tests/WT_S1.R2.fastq.gz .tests/WT_S2.R1.fastq.gz .tests/WT_S2.R2.fastq.gz \
               --output output \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker://snakemake/snakemake:v5.24.2
+      - uses: docker://snakemake/snakemake:v7.32.4
       - name: Dry-run pipeline
         run: |
           docker run -v $PWD:/opt2 -w /opt2 snakemake/snakemake:v5.24.2 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## RENEE development version
 
-- Minor documentation improvements. (#132, @kelly-sovacool)
+- Minor documentation improvements. (#132, #135, @kelly-sovacool)
 - Support hg38 release 45 on biowulf & FRCE. (#127, @kelly-sovacool)
 - Show the name of the pipeline rather than the python script for CLI help messages. (#131, @kelly-sovacool)
-- Improve README with links to documentation website. (#135, @kelly-sovacool)
+- Ensure `renee build` creates necessary `config` directory during initialization. (#139, @kelly-sovacool)
 
 ## RENEE 2.5.12
 

--- a/docs/RNA-seq/build.md
+++ b/docs/RNA-seq/build.md
@@ -83,7 +83,7 @@ Each of the following arguments are required. Failure to provide a required argu
 > **Path to an output directory.**  
 > _type: path_
 >
-> This location is where the build pipeline will create all of its output files. If the user-provided working directory has not been initialized, it will automatically be created.  
+> This location is where the build pipeline will create all of its output files. If the user-provided working directory has not been initialized, it will automatically be created. Note: by default, any files in `config`, `resources,` or `workflow` in the output directory may be overwritten by `renee build`.
 > **_Example:_** `--output /data/$USER/refs/hg38_v36/`
 
 ### 2.2 Build Options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
 ]
 
 [project.scripts]
-renee = "src.renee.__main__:main"
+renee = "renee.src.renee.__main__:main"
 
 [project.urls]
 Repository = "https://github.com/CCBR/RENEE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,11 @@ renee = "src.renee.__main__:main"
 [project.urls]
 Repository = "https://github.com/CCBR/RENEE"
 
+[tool.setuptools.package-dir]
+renee = "."
+
 [tool.setuptools.package-data]
-"*" = ["VERSION"]
+"*" = ["CITATION.cff", "LICENSE", "VERSION", "docker/**", "resources/**", "bin/**", "config/**", "resources/**", "workflow/**", "tests/**", ".tests/**"]
 
 [tool.setuptools.dynamic]
 version = {file = "VERSION"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = [
+    "setuptools >= 62.3.0",
+    "wheel >= 0.29.0",
+]
+build-backend = 'setuptools.build_meta'
+
+[project]
+name = 'RENEE'
+dynamic = ['version','readme']
+description = "Rna sEquencing aNalysis pipElinE"
+authors = [
+    {name = "Kelly Sovacool", email = "kelly.sovacool@nih.gov"},
+    {name = "Samanthe Sevilla"},
+    {name = "Vishal Koparde", email = "vishal.koparde@nih.gov"},
+    {name = "Skyler Kuhn"},
+    {name = "Mayank Tandon"}
+]
+maintainers = [
+    {name = "CCR Collaborative Bioinformatics Resource", email = "ccbr@mail.nih.gov"},
+]
+license = {file = "LICENSE"}
+classifiers = [
+    "Environment :: Console",
+    "Environment :: MacOS X",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT license",
+    "Natural Language :: English",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "Click >= 8.1.3",
+    "snakemake >= 7, < 8",
+    "snaketool-utils >= 0.0.5",
+    "argparse"
+]
+
+[project.optional-dependencies]
+dev = [
+    "black >= 22.0.0",
+    "pre-commit"
+]
+test = [
+    "pytest"
+]
+
+[project.scripts]
+renee = "src.renee.__main__:main"
+
+[project.urls]
+Repository = "https://github.com/CCBR/RENEE"
+
+[tool.setuptools.package-data]
+"*" = ["VERSION"]
+
+[tool.setuptools.dynamic]
+version = {file = "VERSION"}
+readme = {file = "README.md"}

--- a/src/renee/__main__.py
+++ b/src/renee/__main__.py
@@ -24,15 +24,20 @@ import argparse  # potential python3 3rd party package, added in python/3.5
 
 
 # Pipeline Metadata and globals
-# __version__ = "v2.5.2"
+def renee_base(rel_path):
+    basedir = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    )
+    return os.path.join(basedir, rel_path)
+
+
 RENEE_PATH = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 
-vfile = open(os.path.join(RENEE_PATH, "VERSION"), "r")
-__version__ = "v" + vfile.read()
-__version__ = __version__.strip()
-vfile.close()
+with open(renee_base("VERSION"), "r") as vfile:
+    __version__ = f"v{vfile.read().strip()}"
+
 __home__ = os.path.dirname(os.path.abspath(__file__))
 _name = os.path.basename(sys.argv[0])
 _description = "a highly-reproducible RNA-seq pipeline"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import tempfile
 
-from renee.__main__ import _cp_r_safe_
+from renee.src.renee.__main__ import _cp_r_safe_
 
 renee_build = (
     "src/renee/__main__.py build "

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,48 @@
+import contextlib
+import io
+import os
+import pathlib
+import tempfile
+
+from renee.__main__ import _cp_r_safe_
+
+renee_build = (
+    "src/renee/__main__.py build "
+    "--dry-run "
+    "--ref-name test "
+    "--ref-fa .tests/KO_S3.R1.fastq.gz "
+    "--ref-gtf .tests/KO_S3.R1.fastq.gz "
+    "--gtf-ver 0 "
+)
+RENEE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_cp_safe():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        outdir = os.path.join(tmp_dir, "testout")
+        os.makedirs(os.path.join(outdir, "config"))
+        pathlib.Path(os.path.join(outdir, "config", "tmp.txt")).touch()
+        with contextlib.redirect_stdout(io.StringIO()) as stdout:
+            _cp_r_safe_(
+                source=RENEE_PATH,
+                target=outdir,
+                resources=["config"],
+                safe_mode=True,
+            )
+        assert "path exists and `safe_mode` is ON, not copying" in stdout.getvalue()
+
+
+def test_cp_unsafe():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        outdir = os.path.join(tmp_dir, "testout")
+        configdir = os.path.join(outdir, "config")
+        os.makedirs(configdir)
+        pathlib.Path(os.path.join(configdir, "tmp.txt")).touch()
+        with contextlib.redirect_stdout(io.StringIO()) as stdout:
+            _cp_r_safe_(
+                source=RENEE_PATH,
+                target=outdir,
+                resources=["config"],
+                safe_mode=False,
+            )
+        assert not stdout.getvalue() and "config.yaml" in os.listdir(configdir)


### PR DESCRIPTION
## Changes

`_cp_r_safe()` sometimes would not copy files during `renee build` even though the path in the destination directory did not exist (possibly a biowulf filesystem issue). This PR adds `safe_mode` to allow files to be copied even if they already exist in the destination. `safe_mode` is True by default (e.g. during `renee run` initiliazation) but False for `renee build`.

Additionally, the new `pyproject.toml` file allows the renee CLI to be installed like a python package so we can write unit tests for individual functions in renee.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
