### PR TITLE
fix: correct renee base path for cache subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - New contributing guide available on GitHub and the documentation website. (#159, @kelly-sovacool)
 - New `renee debug` subcommand to determine the base directory for debugging purposes. (#159, @kelly-sovacool)
+- Fix `renee cache` subcommand to correctly read the container images config file. (#163, @kelly-sovacool)
 
 ## RENEE 2.6.0
 

--- a/src/renee/__main__.py
+++ b/src/renee/__main__.py
@@ -418,8 +418,7 @@ def cache(sub_args):
     """
     sif_cache = sub_args.sif_cache
     # Get absolute PATH to templates in renee git repo
-    repo_path = os.path.dirname(os.path.abspath(__file__))
-    images = os.path.join(repo_path, "config", "containers", "images.json")
+    images = os.path.join(RENEE_PATH, "config", "containers", "images.json")
 
     # Create image cache
     if not os.path.exists(sif_cache):
@@ -462,7 +461,7 @@ def cache(sub_args):
             username = os.environ.get("USER", os.environ.get("USERNAME"))
             masterjob = subprocess.Popen(
                 "sbatch --parsable -J pl:cache --time=10:00:00 --mail-type=BEGIN,END,FAIL "
-                + str(os.path.join(repo_path, "resources", "cacher"))
+                + str(os.path.join(RENEE_PATH, "resources", "cacher"))
                 + " slurm "
                 + " -s '{}' ".format(sif_cache)
                 + " -i '{}' ".format(",".join(pull))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -67,4 +67,4 @@ def test_cache_in_temp():
     with tempfile.TemporaryDirectory() as tmp_dir:
         outdir = os.path.join(tmp_dir, "testout")
         output = shell_run(f"./bin/renee cache --sif-cache {outdir} --dry-run")
-    assert output.contains("Image will be pulled from")
+    assert "Image will be pulled from" in output

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -61,3 +61,10 @@ def test_get_singularity_cachedir():
     ]
     errors = [assertion for assertion in assertions if not eval(assertion)]
     assert not errors, "errors occurred:\n{}".format("\n".join(errors))
+
+
+def test_cache_in_temp():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        outdir = os.path.join(tmp_dir, "testout")
+        output = shell_run(f"./bin/renee cache --sif-cache {outdir} --dry-run")
+    assert output.contains("Image will be pulled from")


### PR DESCRIPTION
## Changes

Fixes the RENEE base path used to read the images config file. This was leftover from when we refactored to structure the main CLI code under `src/renee/`.

## Issues

resolves #162 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
