### PR TITLE
fix: upgrade rseqc container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Consolidate `build_cluster.json` into `cluster.json`. (#167, @kelly-sovacool)
 - Remove unused miniconda container. (#168, @kelly-sovacool)
+- Fix error in RSEQC rules. (#172, @kelly-sovacool)
 
 ## RENEE 2.6.1
 

--- a/config/containers/images.json
+++ b/config/containers/images.json
@@ -16,7 +16,7 @@
         "qualimap": "docker://nciccbr/ccbr_qualimap:v0.0.1",
         "rna": "docker://nciccbr/ccbr_rna:v0.0.1",
         "rsem": "docker://nciccbr/ccbr_rsem_1.3.3:v1.0",
-        "rseqc": "docker://nciccbr/ccbr_rseqc_4.0.0:v2",
+        "rseqc": "docker://nciccbr/ccbr_rseqc_4.0.0:v3",
         "rstat": "docker://nciccbr/ccbr_rstat:v0.0.1"
     }
 }


### PR DESCRIPTION
## Changes

Upgrade the rseqc docker to use the newer base container which explicitly sets the PYTHONPATH.

## Issues

depends on https://github.com/CCBR/Dockers/pull/40

fixes #171

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
