### PR TITLE
fix: increase memory for fastq validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## RENEE development version
 
-- Increase default memory for fastq validator. (#224, @kelly-sovacool)
+- Improvements for fastq validator: (#224, @kelly-sovacool)
+  - Increase default memory.
+  - Capture stdout in a log file so the output is not deleted on failure.
 
 ## RENEE 2.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## RENEE development version
 
+- Increase default memory for fastq validator. (#224, @kelly-sovacool)
+
 ## RENEE 2.7.0
 
 - RENEE now depends on ccbr_tools v0.4 for updated jobby & spooker utilities. (#207, @kelly-sovacool)

--- a/config/cluster.json
+++ b/config/cluster.json
@@ -123,6 +123,9 @@
     "trim_se": {
         "threads": "32"
     },
+    "validator": {
+        "mem": "16g"
+    },
     "reformat_gtf": {
         "mem": "20g",
         "time": "1:00:00"

--- a/workflow/rules/paired-end.smk
+++ b/workflow/rules/paired-end.smk
@@ -19,7 +19,7 @@ rule validator:
     input:
         R1=join(workpath,"{name}.R1.fastq.gz"),
         R2=join(workpath,"{name}.R2.fastq.gz"),
-    output:
+    log:
         out1=join(workpath,"rawQC","{name}.validated.R1.fastq.log"),
         out2=join(workpath,"rawQC","{name}.validated.R2.fastq.log"),
     priority: 2
@@ -27,11 +27,11 @@ rule validator:
         rname='pl:validator',
         outdir=join(workpath,"rawQC"),
     container: config['images']['fastqvalidator']
-    shell: """
-    mkdir -p {params.outdir}
-    fastQValidator --noeof --minReadLen 2 --file {input.R1} > {output.out1}
-    fastQValidator --noeof --minReadLen 2 --file {input.R2} > {output.out2}
-    """
+    shell:
+        """
+        fastQValidator --noeof --minReadLen 2 --file {input.R1} > {log.out1}
+        fastQValidator --noeof --minReadLen 2 --file {input.R2} > {log.out2}
+        """
 
 
 rule rawfastqc:

--- a/workflow/rules/single-end.smk
+++ b/workflow/rules/single-end.smk
@@ -18,17 +18,17 @@ rule validator:
     """
     input:
         R1=join(workpath,"{name}.R1.fastq.gz"),
-    output:
-        out1=join(workpath,"rawQC","{name}.validated.R1.fastq.log"),
+    log:
+        join(workpath,"rawQC","{name}.validated.R1.fastq.log"),
     priority: 2
     params:
         rname='pl:validator',
         outdir=join(workpath,"rawQC"),
     container: config['images']['fastqvalidator']
-    shell: """
-    mkdir -p {params.outdir}
-    fastQValidator --noeof --minReadLen 2 --file {input.R1} > {output.out1}
-    """
+    shell:
+        """
+        fastQValidator --noeof --minReadLen 2 --file {input.R1} > {log}
+        """
 
 
 rule rawfastqc:


### PR DESCRIPTION
## Changes

fastq validator frequently failed for large datasets. doubled the memory from 8 to 16g

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

<!--
**Reviewers**: Use the @ feature to mention anyone responsible for reviewing/completing this request.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
