### PR TITLE
feat: --partition slurm option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,10 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}
         shell: micromamba-shell {0}
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
 
   build-status: # https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## RENEE development version
 
+- New `--partition` option for `renee run` and `renee build` to specify the SLURM partition. (#252, @kelly-sovacool)
+
 ## RENEE 2.7.3
 
 - Bug fixes: (#246, @kelly-sovacool)

--- a/docs/RNA-seq/build.md
+++ b/docs/RNA-seq/build.md
@@ -13,7 +13,8 @@ Setting up the RENEE build pipeline is fast and easy! In its most basic form, <c
 ```text
 $ renee build [--help] \
              [--shared-resources SHARED_RESOURCES] [--small-genome] \
-             [--dry-run] [--singularity-cache SINGULARITY_CACHE] \
+             [--dry-run] [--partition PARTITION] \
+             [--singularity-cache SINGULARITY_CACHE] \
              [--sif-cache SIF_CACHE] [--tmp-dir TMP_DIR] \
              --ref-fa REF_FA \
              --ref-name REF_NAME \
@@ -122,6 +123,17 @@ Each of the following arguments are optional and do not need to be provided. If 
 > Displays what steps in the build pipeline remain or will be run. Does not execute anything!
 >
 > **_Example:_** `--dry-run`
+
+---
+
+`--partition PARTITION`
+
+> **SLURM partition for job submission.**  
+> _type: string_
+>
+> Name of the SLURM partition to submit the build job to. This option overrides the default partition specified in the cluster configuration file. This is useful when you want to submit jobs to a specific partition on your SLURM cluster. If not provided, the default partition from the cluster configuration will be used.
+>
+> **_Example:_** `--partition norm`
 
 ---
 
@@ -254,7 +266,8 @@ renee build --ref-fa GRCm39.primary_assembly.genome.fa \
               --ref-gtf gencode.vM26.annotation.gtf \
               --gtf-ver M26 \
               --output /data/$USER/refs/mm39_M26 \
-              --sif-cache /data/CCBR_Pipeliner/SIFs/
+              --sif-cache /data/CCBR_Pipeliner/SIFs/ \
+              --partition norm
 ```
 
 ### 5.2 Generic SLURM Cluster
@@ -297,5 +310,6 @@ renee build --ref-fa GRCm39.primary_assembly.genome.fa \
               --output /data/$USER/refs/mm39_M26 \
               --shared-resources /data/shared/renee \
               --tmp-dir /cluster_scratch/$USER/ \
-              --sif-cache /data/$USER/cache
+              --sif-cache /data/$USER/cache \
+              --partition norm
 ```

--- a/docs/RNA-seq/run.md
+++ b/docs/RNA-seq/run.md
@@ -287,5 +287,6 @@ renee run --input .tests/*.R?.fastq.gz \
                --partition norm \
                --star-2-pass-basic \
                --shared-resources /data/shared/renee \
-               --tmp-dir /cluster_scratch/$USER/
+               --tmp-dir /cluster_scratch/$USER/ \
+               --dry-run
 ```

--- a/docs/RNA-seq/run.md
+++ b/docs/RNA-seq/run.md
@@ -14,6 +14,7 @@ Setting up the RENEE pipeline is fast and easy! In its most basic form, <code>re
 $ renee run [--help] \
             [--small-rna] [--star-2-pass-basic] \
             [--dry-run] [--mode {slurm, local}] \
+            [--partition PARTITION] \
             [--shared-resources SHARED_RESOURCES] \
             [--singularity-cache SINGULARITY_CACHE] \
             [--sif-cache SIF_CACHE] \
@@ -130,6 +131,17 @@ Each of the following arguments are optional and do not need to be provided.
 
 ---
 
+`--partition PARTITION`
+
+> **SLURM partition for job submission.**  
+> _type: string_
+>
+> Name of the SLURM partition to submit the pipeline job to. This option overrides the default partition specified in the cluster configuration file. This is useful when you want to submit jobs to a specific partition on your SLURM cluster. If not provided, the default partition from the cluster configuration will be used. This option is only applicable when using `--mode slurm`.
+>
+> **_Example:_** `--partition norm`
+
+---
+
 `--shared-resources SHARED_RESOURCES`
 
 > **Local path to shared resources.**  
@@ -227,7 +239,8 @@ renee run --input .tests/*.R?.fastq.gz \
                --output /data/$USER/RNA_hg38 \
                --genome hg38_36 \
                --mode slurm \
-                --sif-cache /data/OpenOmics/SIFs/ \
+               --sif-cache /data/OpenOmics/SIFs/ \
+               --partition norm \
                --star-2-pass-basic
 ```
 
@@ -271,8 +284,8 @@ renee run --input .tests/*.R?.fastq.gz \
                --genome /data/$USER/hg38_36/hg38_36.json \
                --mode slurm \
                --sif-cache /data/$USER/cache \
+               --partition norm \
                --star-2-pass-basic \
                --shared-resources /data/shared/renee \
-               --tmp-dir /cluster_scratch/$USER/ \
-               --dry-run
+               --tmp-dir /cluster_scratch/$USER/
 ```

--- a/resources/builder
+++ b/resources/builder
@@ -46,6 +46,9 @@ Required Arguments:
                                  set to '/lscratch/\$SLURM_JOBID/'. On FRCE,
                                  this value should be set to the following:
                                  '/scratch/cluster_scratch/\$USER/'.
+  -p, --partition [Type: Str]    SLURM partition to submit jobs to.
+                                 If not provided, defaults to partition
+                                 specified in config/cluster.json
   -h, --hpc-name [Type: Str]     biowulf or frce or unknown
 OPTIONS:
   -o,  --outdir  [Type: Path]  Path to output directory. If not provided, the Path
@@ -88,6 +91,7 @@ function parser() {
       -t  | --tmp-dir) provided "$key" "${2:-}"; Arguments["t"]="$2"; shift; shift;;
       -o  | --outdir)  provided "$key" "${2:-}"; Arguments["o"]="$2"; shift; shift;;
       -w  | --wait)  Arguments["w"]="--wait"; shift;;
+      -p  | --partition) provided "$key" "${2:-}"; Arguments["p"]="$2"; shift; shift;;
       -n  | --hpc-name)  provided "$key" "${2:-}"; Arguments["h"]="$2"; shift; shift;;
       -c  | --cache)  provided "$key" "${2:-}"; Arguments["c"]="$2"; shift; shift;;
       -*  | --*) err "Error: Failed to parse unsupported argument: '${key}'."; usage && exit 1;;
@@ -139,6 +143,7 @@ function submit(){
   # INPUT $6 = Temporary directory for output files
   # INPUT $7 = Wait ("--wait") or no wait ("--nowait".. default)
   # INPUT $8 = HPC name... biowulf or frce or unknown
+  # INPUT $9 = SLURM partition (optional)
 
   # SLURM inherits the environment from which the job was launched
   # Try to purge modules all modules from environment
@@ -171,7 +176,12 @@ function submit(){
     slurm)
           # Create directory for logfiles
           mkdir -p "$3"/logfiles/slurmfiles/
-          CLUSTER_OPTS="sbatch --cpus-per-task {cluster.threads} -p {cluster.partition} -t {cluster.time} --mem {cluster.mem} --job-name {cluster.name} --output {cluster.output} --error {cluster.error}"
+          # If partition provided via CLI, override cluster.json partition
+          if [[ -n "${9:-}" ]]; then
+            CLUSTER_OPTS="sbatch --cpus-per-task {cluster.threads} -p $9 -t {cluster.time} --mem {cluster.mem} --job-name {cluster.name} --output {cluster.output} --error {cluster.error}"
+          else
+            CLUSTER_OPTS="sbatch --cpus-per-task {cluster.threads} -p {cluster.partition} -t {cluster.time} --mem {cluster.mem} --job-name {cluster.name} --output {cluster.output} --error {cluster.error}"
+          fi
           snakemakeVer=$(snakemake --version 2>/dev/null)
           verlte() {
     [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
@@ -282,7 +292,7 @@ function main(){
 
   # Step 1. Run builder pipeline and submit jobs to cluster using the defined executor
   mkdir -p "${Arguments[o]}/logfiles/"
-  job_id=$(submit "${Arguments[e]}" "${Arguments[j]}" "${Arguments[o]}" "${Arguments[b]}" "${Arguments[c]}" "${Arguments[t]}"  "${Arguments[w]}" "${Arguments[h]}")
+  job_id=$(submit "${Arguments[e]}" "${Arguments[j]}" "${Arguments[o]}" "${Arguments[b]}" "${Arguments[c]}" "${Arguments[t]}"  "${Arguments[w]}" "${Arguments[h]}" "${Arguments[p]:-}")
   echo -e "RENEE build reference pipeline submitted to cluster.\nMaster Job ID: $job_id"
   echo "${job_id}" > "${Arguments[o]}/logfiles/bjobid.log"
 

--- a/resources/runner
+++ b/resources/runner
@@ -46,6 +46,9 @@ Required Arguments:
                                  set to '/lscratch/\$SLURM_JOBID/'. On FRCE,
                                  this value should be set to the following:
                                  '/scratch/cluster_scratch/\$USER/'.
+  -p, --partition [Type: Str]    SLURM partition to submit jobs to.
+                                 If not provided, defaults to partition
+                                 specified in config/cluster.json
   -h, --hpc-name [Type: Str]     biowulf or frce or unknown
 OPTIONS:
   -o,  --outdir  [Type: Path]  Path to output directory. If not provided, the Path
@@ -88,6 +91,7 @@ function parser() {
       -t  | --tmp-dir) provided "$key" "${2:-}"; Arguments["t"]="$2"; shift; shift;;
       -o  | --outdir)  provided "$key" "${2:-}"; Arguments["o"]="$2"; shift; shift;;
       -c  | --cache)  provided "$key" "${2:-}"; Arguments["c"]="$2"; shift; shift;;
+      -p  | --partition) provided "$key" "${2:-}"; Arguments["p"]="$2"; shift; shift;;
       -n  | --hpc-name)  provided "$key" "${2:-}"; Arguments["h"]="$2"; shift; shift;;
       -w  | --wait)  Arguments["w"]="--wait"; shift;;
       -*  | --*) err "Error: Failed to parse unsupported argument: '${key}'."; usage && exit 1;;
@@ -138,6 +142,7 @@ function submit(){
   # INPUT $6 = Temporary directory for output files
   # INPUT $7 = Wait ("--wait") or no wait ("--nowait".. default)
   # INPUT $8 = HPC name... biowulf or frce or unknown
+  # INPUT $9 = SLURM partition (optional)
 
   # SLURM inherits the environment from which the job was launched
   # Try to purge modules all modules from environment
@@ -174,7 +179,12 @@ function submit(){
     slurm)
           # Create directory for logfiles
           mkdir -p "$3"/logfiles/slurmfiles/
-          CLUSTER_OPTS="sbatch --cpus-per-task {cluster.threads} -p {cluster.partition} -t {cluster.time} --mem {cluster.mem} --job-name {cluster.name} --output {cluster.output} --error {cluster.error}"
+          # If partition provided via CLI, override cluster.json partition
+          if [[ -n "${9:-}" ]]; then
+            CLUSTER_OPTS="sbatch --cpus-per-task {cluster.threads} -p $9 -t {cluster.time} --mem {cluster.mem} --job-name {cluster.name} --output {cluster.output} --error {cluster.error}"
+          else
+            CLUSTER_OPTS="sbatch --cpus-per-task {cluster.threads} -p {cluster.partition} -t {cluster.time} --mem {cluster.mem} --job-name {cluster.name} --output {cluster.output} --error {cluster.error}"
+          fi
           snakemakeVer=$(snakemake --version 2>/dev/null)
           verlte() {
     [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
@@ -285,7 +295,7 @@ function main(){
 
   # Step 1. Run pipeline and submit jobs to cluster using the defined executor
   mkdir -p "${Arguments[o]}/logfiles/"
-  job_id=$(submit "${Arguments[e]}" "${Arguments[j]}" "${Arguments[o]}" "${Arguments[b]}" "${Arguments[c]}" "${Arguments[t]}" "${Arguments[w]}" "${Arguments[h]}")
+  job_id=$(submit "${Arguments[e]}" "${Arguments[j]}" "${Arguments[o]}" "${Arguments[b]}" "${Arguments[c]}" "${Arguments[t]}" "${Arguments[w]}" "${Arguments[h]}" "${Arguments[p]:-}")
   echo -e "[$(date)] Pipeline submitted to cluster.\nMaster Job ID: $job_id"
   echo "${job_id}" > "${Arguments[o]}/logfiles/mjobid.log"
 

--- a/src/renee/__main__.py
+++ b/src/renee/__main__.py
@@ -34,7 +34,7 @@ from ccbr_tools.pipeline.cache import get_sif_cache_dir, image_cache
 from .run import run
 from .dryrun import dryrun
 from .conditions import fatal
-from .util import renee_base, get_version
+from .util import renee_base, get_version, update_cluster_partition
 from .orchestrate import orchestrate
 
 # Lazy import GUI to avoid hard dependency on tkinter during CLI-only usage/tests
@@ -314,25 +314,11 @@ def configure_build(sub_args, git_repo, output_path):
     )
     # If a partition was provided, update the copied cluster.json default partition
     if hasattr(sub_args, "partition") and sub_args.partition:
-        cluster_json = os.path.join(output_path, "config", "cluster.json")
-        if not os.path.exists(cluster_json):
-            raise FileNotFoundError(
-                f"Expected cluster.json at '{cluster_json}' after build configuration"
-            )
-        with open(cluster_json, "r") as fh:
-            try:
-                cluster_cfg = json.load(fh)
-            except json.JSONDecodeError as e:
-                raise RuntimeError(
-                    f"Malformed JSON in cluster.json at '{cluster_json}'"
-                ) from e
-        if "__default__" not in cluster_cfg:
-            raise KeyError(
-                f"cluster.json missing '__default__' section at '{cluster_json}'"
-            )
-        cluster_cfg["__default__"]["partition"] = sub_args.partition
-        with open(cluster_json, "w") as fh:
-            json.dump(cluster_cfg, fh, indent=4, sort_keys=True)
+        update_cluster_partition(
+            output_path,
+            sub_args.partition,
+            context="after build configuration"
+        )
     _reset_write_permission(target=output_path)
     _configure(
         sub_args=sub_args,

--- a/src/renee/__main__.py
+++ b/src/renee/__main__.py
@@ -33,10 +33,20 @@ from ccbr_tools.pipeline.cache import get_sif_cache_dir, image_cache
 # local imports
 from .run import run
 from .dryrun import dryrun
-from .gui import launch_gui
 from .conditions import fatal
 from .util import renee_base, get_version
 from .orchestrate import orchestrate
+
+# Lazy import GUI to avoid hard dependency on tkinter during CLI-only usage/tests
+try:
+    from .gui import launch_gui
+except Exception as exc:
+
+    def launch_gui(*args, **kwargs):  # type: ignore
+        raise RuntimeError(
+            "GUI dependencies are missing (requires tkinter). Install tkinter to use the GUI."
+        ) from exc
+
 
 # Pipeline Metadata and globals
 RENEE_PATH = os.path.dirname(

--- a/src/renee/initialize.py
+++ b/src/renee/initialize.py
@@ -1,8 +1,9 @@
 import os
-import json
 import sys
 
 from ccbr_tools.pipeline.util import _cp_r_safe_, _sym_safe_
+
+from .util import update_cluster_partition
 
 
 def initialize(sub_args, repo_path, output_path):
@@ -47,25 +48,11 @@ def initialize(sub_args, repo_path, output_path):
 
     # If a partition was provided, update the copied cluster.json default partition
     if hasattr(sub_args, "partition") and sub_args.partition:
-        cluster_json = os.path.join(output_path, "config", "cluster.json")
-        if not os.path.exists(cluster_json):
-            raise FileNotFoundError(
-                f"Expected cluster.json at '{cluster_json}' after initialization"
-            )
-        with open(cluster_json, "r") as fh:
-            try:
-                cluster_cfg = json.load(fh)
-            except json.JSONDecodeError as e:
-                raise RuntimeError(
-                    f"Malformed JSON in cluster.json at '{cluster_json}'"
-                ) from e
-        if "__default__" not in cluster_cfg:
-            raise KeyError(
-                f"cluster.json missing '__default__' section at '{cluster_json}'"
-            )
-        cluster_cfg["__default__"]["partition"] = sub_args.partition
-        with open(cluster_json, "w") as fh:
-            json.dump(cluster_cfg, fh, indent=4, sort_keys=True)
+        update_cluster_partition(
+            output_path,
+            sub_args.partition,
+            context="after initialization"
+        )
 
     # Create renamed symlinks to rawdata
     inputs = _sym_safe_(input_data=sub_args.input, target=output_path)

--- a/src/renee/initialize.py
+++ b/src/renee/initialize.py
@@ -1,5 +1,5 @@
 import os
-import re
+import json
 import sys
 
 from ccbr_tools.pipeline.util import _cp_r_safe_, _sym_safe_
@@ -44,6 +44,28 @@ def initialize(sub_args, repo_path, output_path):
         target=output_path,
         resources=["workflow", "resources", "config"],
     )
+
+    # If a partition was provided, update the copied cluster.json default partition
+    if hasattr(sub_args, "partition") and sub_args.partition:
+        cluster_json = os.path.join(output_path, "config", "cluster.json")
+        if not os.path.exists(cluster_json):
+            raise FileNotFoundError(
+                f"Expected cluster.json at '{cluster_json}' after initialization"
+            )
+        with open(cluster_json, "r") as fh:
+            try:
+                cluster_cfg = json.load(fh)
+            except json.JSONDecodeError as e:
+                raise RuntimeError(
+                    f"Malformed JSON in cluster.json at '{cluster_json}'"
+                ) from e
+        if "__default__" not in cluster_cfg:
+            raise KeyError(
+                f"cluster.json missing '__default__' section at '{cluster_json}'"
+            )
+        cluster_cfg["__default__"]["partition"] = sub_args.partition
+        with open(cluster_json, "w") as fh:
+            json.dump(cluster_cfg, fh, indent=4, sort_keys=True)
 
     # Create renamed symlinks to rawdata
     inputs = _sym_safe_(input_data=sub_args.input, target=output_path)

--- a/src/renee/orchestrate.py
+++ b/src/renee/orchestrate.py
@@ -20,6 +20,7 @@ def orchestrate(
     tmp_dir=None,
     wait="",
     hpcname=get_hpcname(),
+    partition=None,
 ):
     """Runs RENEE pipeline via selected executor: local or slurm.
     If 'local' is selected, the pipeline is executed locally on a compute node/instance.
@@ -49,6 +50,8 @@ def orchestrate(
         "--wait" to wait for master job to finish. This waits when pipeline is called via NIDAP API
     @param hpcname <str>:
         "biowulf" if run on biowulf, "frce" if run on frce, blank otherwise. hpcname is determined in setup() function
+    @param partition <str>:
+        SLURM partition to submit jobs to. If not provided, defaults to partition in cluster.json
     @return masterjob <subprocess.Popen() object>:
     """
     # Add additional singularity bind PATHs
@@ -151,6 +154,9 @@ def orchestrate(
             "-t",
             str(tmp_dir),
         ]
+        if partition is not None and str(partition) != "":
+            cmdlist.append("-p")
+            cmdlist.append(str(partition))
         if str(wait) == "--wait":
             cmdlist.append("-w")
         if str(hpcname) != "":

--- a/src/renee/run.py
+++ b/src/renee/run.py
@@ -96,6 +96,7 @@ def run(sub_args):
             tmp_dir=get_tmp_dir(sub_args.tmp_dir, sub_args.output),
             wait=wait,
             hpcname=hpcname,
+            partition=sub_args.partition,
         )
 
         # Wait for subprocess to complete,

--- a/src/renee/setup.py
+++ b/src/renee/setup.py
@@ -87,6 +87,9 @@ def setup(sub_args, ifiles, repo_path, output_path):
     config["options"]["small_rna"] = sub_args.small_rna
     config["options"]["tmp_dir"] = get_tmp_dir(sub_args.tmp_dir, output_path)
     config["options"]["shared_resources"] = sub_args.shared_resources
+    # Record chosen partition for traceability
+    if hasattr(sub_args, "partition") and sub_args.partition:
+        config["options"]["partition"] = sub_args.partition
     if sub_args.wait:
         config["options"]["wait"] = "True"
     else:

--- a/src/renee/util.py
+++ b/src/renee/util.py
@@ -1,4 +1,7 @@
+import json
+import os
 import pathlib
+
 from ccbr_tools.pipeline.util import get_hpcname
 
 
@@ -35,3 +38,46 @@ def get_shared_resources_dir(shared_dir, hpc=get_hpcname()):
         elif hpc == "frce":
             shared_dir = "/mnt/projects/CCBR-Pipelines/pipelines/RENEE/resources/shared_resources"
     return shared_dir
+
+
+def update_cluster_partition(output_path, partition, context=""):
+    """Update the default partition in cluster.json.
+    
+    Reads cluster.json from the output directory, updates the __default__ partition,
+    and writes it back with proper formatting.
+    
+    @param output_path <str>:
+        Path to the output directory containing config/cluster.json
+    @param partition <str>:
+        The partition name to set in cluster.json
+    @param context <str>:
+        Optional context string for error messages (e.g., "after initialization")
+    @raises FileNotFoundError: If cluster.json doesn't exist
+    @raises RuntimeError: If cluster.json is malformed JSON
+    @raises KeyError: If cluster.json is missing the __default__ section
+    """
+    cluster_json = os.path.join(output_path, "config", "cluster.json")
+    context_msg = f" {context}" if context else ""
+    
+    if not os.path.exists(cluster_json):
+        raise FileNotFoundError(
+            f"Expected cluster.json at '{cluster_json}'{context_msg}"
+        )
+    
+    with open(cluster_json, "r") as fh:
+        try:
+            cluster_cfg = json.load(fh)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(
+                f"Malformed JSON in cluster.json at '{cluster_json}'"
+            ) from e
+    
+    if "__default__" not in cluster_cfg:
+        raise KeyError(
+            f"cluster.json missing '__default__' section at '{cluster_json}'"
+        )
+    
+    cluster_cfg["__default__"]["partition"] = partition
+    
+    with open(cluster_json, "w") as fh:
+        json.dump(cluster_cfg, fh, indent=4, sort_keys=True)

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -26,7 +26,7 @@ def test_run_init_partition_overrides_cluster_json():
     # Provide partition 'long' and verify it's written to cluster.json
     base_cmd = (
         "./main.py run --mode local --runmode init --dry-run "
-        "--input .tests/*.fastq.gz --partition long"
+        "--input .tests/*.fastq.gz --genome config/genomes/biowulf/hg38_38.json --partition long"
     )
     cluster = _run_cmd_in_tmp(base_cmd)
     assert (

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -1,0 +1,50 @@
+import json
+import os
+import subprocess
+import tempfile
+
+# These tests exercise the lightweight path where resources are copied
+# and cluster.json is updated from the CLI --partition option.
+
+
+def _run_cmd_in_tmp(command: str):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        outdir = os.path.join(tmp_dir, "out")
+        cmd = f"{command} --output {outdir}"
+        # We don't assert on return code; init/build may continue to later steps
+        # that require more inputs. We only care that cluster.json is updated.
+        subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        cluster_path = os.path.join(outdir, "config", "cluster.json")
+        assert os.path.exists(cluster_path), f"Expected {cluster_path} to exist"
+        with open(cluster_path, "r") as fh:
+            cluster = json.load(fh)
+        return cluster
+
+
+def test_run_init_partition_overrides_cluster_json():
+    # Use runmode init so initialize() executes and copies resources.
+    # Provide partition 'long' and verify it's written to cluster.json
+    base_cmd = (
+        "./main.py run --mode local --runmode init --dry-run "
+        "--input .tests/*.fastq.gz --partition long"
+    )
+    cluster = _run_cmd_in_tmp(base_cmd)
+    assert (
+        cluster.get("__default__", {}).get("partition") == "long"
+    ), "cluster.json __default__.partition should be set to 'long' from CLI"
+
+
+def test_build_partition_overrides_cluster_json():
+    # Build path: copy resources and update cluster.json immediately
+    base_cmd = (
+        "./main.py build --dry-run "
+        "--ref-name test "
+        "--ref-fa .tests/KO_S3.R1.fastq.gz "
+        "--ref-gtf .tests/KO_S3.R1.fastq.gz "
+        "--gtf-ver 0 "
+        "--partition short"
+    )
+    cluster = _run_cmd_in_tmp(base_cmd)
+    assert (
+        cluster.get("__default__", {}).get("partition") == "short"
+    ), "cluster.json __default__.partition should be set to 'short' from CLI"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,6 @@
 import contextlib
 import io
+import json
 import os
 import pathlib
 import pytest
@@ -12,7 +13,7 @@ from ccbr_tools.pipeline.util import (
     get_genomes_list,
 )
 
-from renee.src.renee.util import renee_base
+from renee.src.renee.util import renee_base, update_cluster_partition
 
 
 def test_renee_base():
@@ -78,3 +79,137 @@ def test_get_genomes_error():
 def test_get_genomes_biowulf():
     genomes_dict = get_genomes_dict(repo_base=renee_base, hpcname="biowulf")
     assert len(genomes_dict) > 10
+
+
+def test_update_cluster_partition_success():
+    """Test successfully updating cluster.json partition."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Set up test directory structure
+        config_dir = os.path.join(tmp_dir, "config")
+        os.makedirs(config_dir)
+        cluster_json_path = os.path.join(config_dir, "cluster.json")
+        
+        # Create a valid cluster.json
+        cluster_data = {
+            "__default__": {
+                "partition": "norm",
+                "mem": "8g",
+                "threads": "1"
+            },
+            "some_rule": {
+                "mem": "16g"
+            }
+        }
+        with open(cluster_json_path, "w") as fh:
+            json.dump(cluster_data, fh, indent=4, sort_keys=True)
+        
+        # Update the partition
+        update_cluster_partition(tmp_dir, "long")
+        
+        # Verify the update
+        with open(cluster_json_path, "r") as fh:
+            updated_data = json.load(fh)
+        
+        assert updated_data["__default__"]["partition"] == "long"
+        assert updated_data["__default__"]["mem"] == "8g"  # Other fields unchanged
+        assert updated_data["some_rule"]["mem"] == "16g"  # Other rules unchanged
+
+
+def test_update_cluster_partition_with_context():
+    """Test that context appears in error messages when provided."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Don't create cluster.json - should raise FileNotFoundError
+        with pytest.raises(FileNotFoundError) as exc_info:
+            update_cluster_partition(tmp_dir, "long", context="after initialization")
+        
+        assert "after initialization" in str(exc_info.value)
+        assert "cluster.json" in str(exc_info.value)
+
+
+def test_update_cluster_partition_file_not_found():
+    """Test FileNotFoundError when cluster.json doesn't exist."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        os.makedirs(os.path.join(tmp_dir, "config"))
+        # Don't create cluster.json
+        
+        with pytest.raises(FileNotFoundError) as exc_info:
+            update_cluster_partition(tmp_dir, "short")
+        
+        assert "cluster.json" in str(exc_info.value)
+
+
+def test_update_cluster_partition_malformed_json():
+    """Test RuntimeError when cluster.json contains malformed JSON."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        config_dir = os.path.join(tmp_dir, "config")
+        os.makedirs(config_dir)
+        cluster_json_path = os.path.join(config_dir, "cluster.json")
+        
+        # Write malformed JSON
+        with open(cluster_json_path, "w") as fh:
+            fh.write("{invalid json content")
+        
+        with pytest.raises(RuntimeError) as exc_info:
+            update_cluster_partition(tmp_dir, "long")
+        
+        assert "Malformed JSON" in str(exc_info.value)
+        assert "cluster.json" in str(exc_info.value)
+
+
+def test_update_cluster_partition_missing_default_section():
+    """Test KeyError when cluster.json is missing __default__ section."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        config_dir = os.path.join(tmp_dir, "config")
+        os.makedirs(config_dir)
+        cluster_json_path = os.path.join(config_dir, "cluster.json")
+        
+        # Create cluster.json without __default__ section
+        cluster_data = {
+            "some_rule": {
+                "partition": "norm",
+                "mem": "16g"
+            }
+        }
+        with open(cluster_json_path, "w") as fh:
+            json.dump(cluster_data, fh, indent=4, sort_keys=True)
+        
+        with pytest.raises(KeyError) as exc_info:
+            update_cluster_partition(tmp_dir, "long")
+        
+        assert "__default__" in str(exc_info.value)
+        assert "cluster.json" in str(exc_info.value)
+
+
+def test_update_cluster_partition_preserves_formatting():
+    """Test that the function preserves JSON formatting (indent=4, sort_keys=True)."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        config_dir = os.path.join(tmp_dir, "config")
+        os.makedirs(config_dir)
+        cluster_json_path = os.path.join(config_dir, "cluster.json")
+        
+        # Create a cluster.json with multiple keys to verify sorting
+        cluster_data = {
+            "__default__": {
+                "partition": "norm",
+                "mem": "8g",
+                "threads": "1"
+            },
+            "z_rule": {"mem": "16g"},
+            "a_rule": {"mem": "32g"}
+        }
+        with open(cluster_json_path, "w") as fh:
+            json.dump(cluster_data, fh, indent=4, sort_keys=True)
+        
+        # Update the partition
+        update_cluster_partition(tmp_dir, "long")
+        
+        # Read the raw file content to check formatting
+        with open(cluster_json_path, "r") as fh:
+            content = fh.read()
+        
+        # Verify indentation (4 spaces)
+        assert '    "__default__"' in content
+        # Verify sorting: a_rule should come before z_rule
+        a_pos = content.index('"a_rule"')
+        z_pos = content.index('"z_rule"')
+        assert a_pos < z_pos


### PR DESCRIPTION
## Changes

Added `--partition` option to `renee build` and `renee run` to set the slurm partition. Modifies the default partition in cluster.json and the partition used by sbatch to submit the main job.

## Issues

resolves #248 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
