### PR TITLE
fix: properly detect phred encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## RENEE development version
 
 - New `--partition` option for `renee run` and `renee build` to specify the SLURM partition. (#252, @kelly-sovacool)
+- Fix bug in `phred_encoding.py` that incorrectly detected Phred+33 files as Phred+64, causing BBMerge to fail. (#257, @kelly-sovacool)
 
 ## RENEE 2.7.3
 

--- a/tests/test_phred_encoding.py
+++ b/tests/test_phred_encoding.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+"""
+Unit tests for phred_encoding.py script.
+
+Tests ensure correct detection of Phred+33 and Phred+64 quality score encodings
+in FastQ files.
+"""
+
+import pytest
+import sys
+import os
+import gzip
+import tempfile
+from pathlib import Path
+
+# Add the workflow/scripts directory to the path
+sys.path.insert(0, str(Path(__file__).parent.parent / "workflow" / "scripts"))
+
+from phred_encoding import detect_encoding_from_qscore, reader, main
+
+
+class TestDetectEncodingFromQScore:
+    """Test the detect_encoding_from_qscore() function with various quality score strings."""
+
+    def test_phred33_with_unique_chars_low_quality(self):
+        """Test Phred+33 quality scores with unique low-quality characters."""
+        # Characters like !, ", #, $, etc. (ASCII 33-39) only exist in Phred+33
+        qscore = "!!###$$$%%%"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_phred33_with_unique_chars_mid_quality(self):
+        """Test Phred+33 quality scores with unique mid-quality characters."""
+        # Characters like +, -, ., / (ASCII 43-47) only exist in Phred+33
+        qscore = "+++---...///"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_phred33_with_unique_chars_numbers(self):
+        """Test Phred+33 quality scores with digit characters."""
+        # Digits 0-9 and : ; < = > ? (ASCII 48-63) only exist in Phred+33
+        qscore = "0123456789:;<=>?"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_phred33_modern_illumina(self):
+        """Test modern Illumina Phred+33 quality scores."""
+        # Modern Illumina with some low-quality characters
+        qscore = "AAAFFJJFJJJJJJFJJJJJJJJJJFJAJJJJJFJJJJJFFJJAJJJJ7JJ"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_phred33_with_comma(self):
+        """Test Phred+33 with comma character (common in lower quality reads)."""
+        # Comma (ASCII 44) is unique to Phred+33
+        qscore = ",AFFFFKKKKFKKKKKKKKKKK"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_phred33_mixed_quality(self):
+        """Test Phred+33 with mixed quality characters."""
+        qscore = "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII9IG9ICIIIIIIIIIIIIIIIIIIII"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_ambiguous_high_quality_returns_none(self):
+        """Test that high-quality scores only (ASCII 64+) return None (ambiguous)."""
+        # Only characters that could be in both encodings
+        qscore = "@@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghi"
+        assert detect_encoding_from_qscore(qscore) is None
+
+    def test_all_high_quality_K(self):
+        """Test quality string with only K characters (ambiguous, returns None)."""
+        qscore = "KKKKKKKKKKKKKKKKKKKK"
+        assert detect_encoding_from_qscore(qscore) is None
+
+    def test_empty_string(self):
+        """Test empty quality score string returns None."""
+        qscore = ""
+        assert detect_encoding_from_qscore(qscore) is None
+
+    def test_single_unique_phred33_char(self):
+        """Test that even a single unique Phred+33 character is detected."""
+        # One unique Phred+33 character (!) among ambiguous characters
+        qscore = "KKKKKKKKK!KKKKKKKK"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+
+class TestReaderFunction:
+    """Test the reader() function for file handling."""
+
+    def test_reader_gzipped_file(self):
+        """Test that reader returns gzip.open for .gz files."""
+        fname = "test.fastq.gz"
+        assert reader(fname) == gzip.open
+
+    def test_reader_uncompressed_file(self):
+        """Test that reader returns open for non-.gz files."""
+        fname = "test.fastq"
+        assert reader(fname) == open
+
+
+class TestFullWorkflow:
+    """Test the full workflow with actual temporary FastQ files."""
+
+    def test_phred33_fastq_uncompressed(self):
+        """Test detection with uncompressed Phred+33 FastQ file."""
+        # Create a temporary uncompressed FastQ file with Phred+33 encoding
+        content = """@SEQ_ID_1
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+!''*((((***+))%%%++)(%%%%).1***-+*''))**55CCF>>>>>>CCCCCCC65
+@SEQ_ID_2
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII9IG9ICIIIIIIIIIIIIIIIIIIII
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".fastq", delete=False) as f:
+            f.write(content)
+            temp_file = f.name
+
+        try:
+            encoding = main(temp_file)
+            assert encoding == "33"
+        finally:
+            os.unlink(temp_file)
+
+    def test_phred33_fastq_compressed(self):
+        """Test detection with gzipped Phred+33 FastQ file."""
+        # Create a temporary gzipped FastQ file with Phred+33 encoding
+        content = b"""@SEQ_ID_1
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+!''*((((***+))%%%++)(%%%%).1***-+*''))**55CCF>>>>>>CCCCCCC65
+@SEQ_ID_2
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+AAAFFJJFJJJJJJFJJJJJJJJJJFJAJJJJJFJJJJJFFJJAJJJJ7JJJJJJJJJJ
+"""
+        with tempfile.NamedTemporaryFile(suffix=".fastq.gz", delete=False) as f:
+            with gzip.open(f.name, "wb") as gz:
+                gz.write(content)
+            temp_file = f.name
+
+        try:
+            encoding = main(temp_file)
+            assert encoding == "33"
+        finally:
+            os.unlink(temp_file)
+
+    def test_phred64_like_fastq(self):
+        """Test detection with FastQ file using only Phred+64 characters."""
+        # Only use characters ASCII 64+ (Phred+64 encoded)
+        # Should be detected as Phred+64
+        content = """@SEQ_ID_1
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+@@BCDEFGHIJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
+@SEQ_ID_2
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
+@SEQ_ID_3
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+@@@@BBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMNNNNOOO
+@SEQ_ID_4
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".fastq", delete=False) as f:
+            f.write(content)
+            temp_file = f.name
+
+        try:
+            encoding = main(temp_file)
+            assert encoding == "64"
+        finally:
+            os.unlink(temp_file)
+
+    def test_modern_illumina_real_world(self):
+        """Test with real-world modern Illumina quality scores."""
+        # Based on actual Illumina HiSeq/NovaSeq data
+        content = b"""@K00193:38:H3MYFBBXX:4:1101:10003:44458/1
+TTCCTTATGAAACAGGAAGAGTCCCTGGGCCCAGGCCTGGCCCACGGTTGT
++
+AAFFFKKKKKKKKKKKKKKKKKKKKKKKKFKKFKKKKF<AAKKKKKKKKKKK
+@K00193:38:H3MYFBBXX:4:1101:10003:46427/1
+CGCCTGGCGACCTTGGTGTCCGCGATGTGGATCATGTCCTTATCAATGTAG
++
+,AFFFFKKKKFKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKK
+"""
+        with tempfile.NamedTemporaryFile(suffix=".fastq.gz", delete=False) as f:
+            with gzip.open(f.name, "wb") as gz:
+                gz.write(content)
+            temp_file = f.name
+
+        try:
+            encoding = main(temp_file)
+            # Should detect Phred+33 due to '<' and ',' characters
+            assert encoding == "33"
+        finally:
+            os.unlink(temp_file)
+
+
+class TestEdgeCases:
+    """Test edge cases and special scenarios."""
+
+    def test_very_low_quality_phred33(self):
+        """Test very low quality Phred+33 scores (ASCII 33-40)."""
+        qscore = "!\"#$%&'()"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_boundary_character_question_mark(self):
+        """Test '?' character (ASCII 63, last unique Phred+33 character)."""
+        qscore = "???????????"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_boundary_character_at_sign(self):
+        """Test '@' character (ASCII 64, first ambiguous character)."""
+        qscore = "@@@@@@@@@@@"
+        assert detect_encoding_from_qscore(qscore) is None  # Ambiguous, returns None
+
+    def test_mixed_unique_and_ambiguous(self):
+        """Test mix of unique Phred+33 and ambiguous characters."""
+        qscore = "AAAFFF###JJJJJJ"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_single_character_unique(self):
+        """Test single unique Phred+33 character."""
+        qscore = "!"
+        assert detect_encoding_from_qscore(qscore) == "33"
+
+    def test_single_character_ambiguous(self):
+        """Test single ambiguous character returns None."""
+        qscore = "K"
+        assert detect_encoding_from_qscore(qscore) is None
+
+
+class TestPhred64Detection:
+    """Test cases specifically for Phred+64 detection."""
+
+    def test_phred64_fastq_compressed(self):
+        """Test detection of true Phred+64 encoded gzipped FastQ."""
+        # Phred+64 file - only ASCII 64+ characters
+        content = b"""@SEQ_ID_1
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+@@BCDEFGHIJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ
+@SEQ_ID_2
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
+@SEQ_ID_3
+GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT
++
+@@@BBBCCCDDDEEEFFFGGGHHHIIIJJJKKKLLLMMMNNNOOOPPPQQQRRRSSSTTT
+"""
+        with tempfile.NamedTemporaryFile(suffix=".fastq.gz", delete=False) as f:
+            with gzip.open(f.name, "wb") as gz:
+                gz.write(content)
+            temp_file = f.name
+
+        try:
+            encoding = main(temp_file)
+            assert encoding == "64"
+        finally:
+            os.unlink(temp_file)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/workflow/scripts/phred_encoding.py
+++ b/workflow/scripts/phred_encoding.py
@@ -2,163 +2,134 @@
 # -*- coding: UTF-8 -*-
 
 from __future__ import print_function, division
-import sys, gzip
+import sys
+import gzip
+from argparse import ArgumentParser
 
-# USAGE
-# sys.argv[1] = sample_name.R1.fastq.gz
-
-# EXAMPLE
-# $ python phred_encoding.py input.R1.fastq.gz input
-
-# ABOUT
-# Older FastQ files may have quality scores that are encoded with Phred-64.
-# This can cause problems with BBmerge, and can cause it to error out. As so,
-# this script is used to infer the encoding type to pass that information to
-# the qin option of bbmerge:
-
-# @J00170:88:ANYVJBBXX:8:1101:1600:1244 1:N:0:ACTTGA
-# GGGAAGTTGAAAGCTTCCAGTGCTCCCTGTCAATTCTAGTCCCTCCAGTCT
-# +
-# AAAFFJJFJJJJJJFJJJJJJJJJJFJAJJJJJFJJJJJFFJJAJJJJ7JJ <- Determine if Phred-33 encoding or Phred-64
+# Constants for Phred encoding detection
+PHRED33_MIN_ASCII = 33
+PHRED33_MAX_ASCII = 63
+PHRED64_MIN_ASCII = 64
+PHRED33_ENCODING = "33"
+PHRED64_ENCODING = "64"
+MAX_QUALITY_LINES_TO_CHECK = 10000
+FASTQ_QUALITY_LINE_POSITION = 3
 
 
 def usage(message="", exitcode=0):
-    """Displays help and usage information. If provided invalid usage
-    returns non-zero exit-code. Additional message can be displayed with
-    the 'message' parameter.
+    """Display help and usage information.
+
+    Args:
+        message: Optional error message to display
+        exitcode: Exit code to use (0 for help, 1 for error)
     """
-    print("Usage: python {} sampleName.R1.fastq.gz".format(sys.argv[0]))
+    print("Usage: python {} fastq_file".format(sys.argv[0]))
     if message:
         print(message)
     sys.exit(exitcode)
 
 
 def reader(fname):
-    """Returns correct file object handler or reader for gzipped
-    or non-gzipped FastQ files based on the file extension. Assumes
-    gzipped files endwith the '.gz' extension.
+    """Return appropriate file handler for gzipped or uncompressed FastQ files.
+
+    Args:
+        fname: Path to FastQ file (.gz extension triggers gzip.open)
+
+    Returns:
+        File handler function (gzip.open or open)
     """
-    if fname.endswith(".gz"):
-        # Opens up file with gzip handler
-        return gzip.open
-    else:
-        # Opens up file normal, uncompressed handler
-        return open
+    return gzip.open if fname.endswith(".gz") else open
 
 
-def decoded(qscore):
-    """Returns Phred ASCII encoding type of FastQ quality scores.
-    Older FastQ files may use Phred 64 encoding.
+def detect_encoding_from_qscore(qscore):
+    """Detect Phred encoding from a quality score string.
+
+    Checks if quality score contains characters unique to Phred+33 (ASCII 33-63).
+
+    Args:
+        qscore: Quality score string from FastQ file
+
+    Returns:
+        str: "33" if Phred+33 characters found, None if ambiguous (all ASCII >= 64)
     """
-    encoding = ""
-    # Unique set of characters across both Phred encoding types
-    encodings = {  # Pred-33 Encoding characters
-        "!": "33",
-        "#": "33",
-        '"': "33",
-        "%": "33",
-        "$": "33",
-        "'": "33",
-        "&": "33",
-        ")": "33",
-        "(": "33",
-        "+": "33",
-        "*": "33",
-        "-": "33",
-        ",": "33",
-        "/": "33",
-        ".": "33",
-        "1": "33",
-        "0": "33",
-        "3": "33",
-        "2": "33",
-        "5": "33",
-        "4": "33",
-        "7": "33",
-        "6": "33",
-        "9": "33",
-        "8": "33",
-        ";": "33",
-        ":": "33",
-        "=": "33",
-        "<": "33",
-        "?": "33",
-        ">": "33",
-        # Pred-64 Encoding characters
-        "K": "64",
-        "M": "64",
-        "L": "64",
-        "O": "64",
-        "N": "64",
-        "Q": "64",
-        "P": "64",
-        "S": "64",
-        "R": "64",
-        "U": "64",
-        "T": "64",
-        "W": "64",
-        "V": "64",
-        "Y": "64",
-        "X": "64",
-        "[": "64",
-        "Z": "64",
-        "]": "64",
-        "\\": "64",
-        "_": "64",
-        "^": "64",
-        "a": "64",
-        "`": "64",
-        "c": "64",
-        "b": "64",
-        "e": "64",
-        "d": "64",
-        "g": "64",
-        "f": "64",
-        "i": "64",
-        "h": "64",
-    }
-
     for char in qscore:
-        try:
-            encoding = encodings[char]
-            break
-        except KeyError:
-            pass
+        ascii_val = ord(char)
+        if ascii_val <= PHRED33_MAX_ASCII:
+            # Found character unique to Phred+33
+            return PHRED33_ENCODING
 
-    return encoding
+    # No unique Phred+33 characters found - ambiguous, needs more data
+    return None
+
+
+def get_min_ascii_in_string(text):
+    """Get the minimum ASCII value in a string.
+
+    Args:
+        text: Input string
+
+    Returns:
+        int: Minimum ASCII value, or None if string is empty
+    """
+    if not text:
+        return None
+    return min(ord(char) for char in text)
+
+
+def main(filename):
+    """Determine the Phred encoding of a FastQ file.
+
+    Samples up to MAX_QUALITY_LINES_TO_CHECK quality lines from the FastQ file
+    to determine if it uses Phred+33 or Phred+64 encoding.
+
+    Args:
+        filename: Path to FastQ file (can be gzipped or uncompressed)
+
+    Returns:
+        str: "33" for Phred+33 encoding, "64" for Phred+64 encoding
+    """
+    handle = reader(filename)
+    encoding = None
+    min_ascii_seen = None
+    quality_lines_checked = 0
+
+    with handle(filename, "rt") as fastq:
+        for line_num, line in enumerate(fastq):
+            # Quality scores are at position 3 (0-indexed) in FastQ format
+            if line_num % 4 == FASTQ_QUALITY_LINE_POSITION:
+                line = line.strip()
+
+                # Check for Phred+33 unique characters
+                result = detect_encoding_from_qscore(line)
+                if result == PHRED33_ENCODING:
+                    # Found definitive Phred+33 character
+                    return PHRED33_ENCODING
+
+                # Track minimum ASCII value
+                line_min_ascii = get_min_ascii_in_string(line)
+                if line_min_ascii is not None:
+                    if min_ascii_seen is None or line_min_ascii < min_ascii_seen:
+                        min_ascii_seen = line_min_ascii
+
+                quality_lines_checked += 1
+                if quality_lines_checked >= MAX_QUALITY_LINES_TO_CHECK:
+                    break
+
+    # Determine encoding based on what we found
+    if min_ascii_seen is not None and min_ascii_seen >= PHRED64_MIN_ASCII:
+        # All quality scores were >= ASCII 64, likely Phred+64
+        return PHRED64_ENCODING
+
+    # Default to Phred+33 (modern standard) if uncertain
+    return PHRED33_ENCODING
 
 
 if __name__ == "__main__":
-    # Check Arguments
-    if "-h" in sys.argv or "--help" in sys.argv or "-help" in sys.argv:
-        usage(exitcode=0)
-    elif len(sys.argv) != 2:
-        usage(
-            message="Error: failed to provide all required positional arguments!",
-            exitcode=1,
-        )
+    parser = ArgumentParser(
+        description="Detect Phred encoding (33 or 64) of a FastQ file"
+    )
+    parser.add_argument("fastq_file", help="Path to FastQ file (can be gzipped)")
 
-    # Get file name
-    filename = sys.argv[1]
-
-    # Set handler for gzipped or uncompressed file
-    handle = reader(filename)
-    # Default encoding if not found
-    encoding = "33"
-
-    # Open in 'rt' mode to maintain compatibility across python2 and python3
-    # python3 default mode is 'rb' and will return a byte string representation
-    with handle(filename, "rt") as fastq:
-        i = 0
-        for line in fastq:
-            line = line.strip()
-            if i % 4 == 3:  # Quality scores
-                encoded = decoded(line)
-                if encoded:
-                    # Found Phred ASCII encoding type (33 vs. 64)
-                    encoding = encoded
-                    break  # Stop Iteration
-            i += 1
-
-    # Print encoding to standard output
+    args = parser.parse_args()
+    encoding = main(args.fastq_file)
     print(encoding)


### PR DESCRIPTION
## Changes

The script was incorrectly detecting Phred+33 quality-encoded FastQ files as Phred+64, causing BBMerge to fail with k-mer errors. The root cause was flawed logic that misclassified characters present in both encodings (ASCII 64+) as unique to Phred+64.

Properly identify characters unique to Phred+33 (ASCII 33-63) and only return Phred+64 when all quality scores are >= ASCII 64 across sampled lines.

Also created unit tests.

## Issues

Fixes #247

## Testing

```sh
./bin/renee run --mode slurm \            
  --input /data/classes/BTEP/hcc1395_renee_b4b/reads/*.fastq.gz \
  --output /data/sovacoolkl/renee_btep_hcc1319_chr22 \
  --genome /data/sovacoolkl/renee_hg38_chr22/hg38_chr22_45.json \
  --sif-cache /data/CCBR_Pipeliner/SIFs
```

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
