### PR TITLE
fix: upgrade ccbr_tools to v0.5.3 to resolve rpds import error (#282)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ site/
 # other
 
 **/.koparde*
+plans/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "biopython",
-    "ccbr_tools@git+https://github.com/CCBR/Tools@v0.4",
+    "ccbr_tools@git+https://github.com/CCBR/Tools@v0.5.3",
     "Click >= 8.1.3",
     "HTSeq",
     "numpy",


### PR DESCRIPTION
## Summary

Upgrades `ccbr_tools` from v0.4 to v0.5.3 to resolve `ModuleNotFoundError: No module named 'rpds.rpds'` when running RENEE on Python 3.12.

## Root Cause

The `rpds` module is a compiled C extension (`.so` file) built only for Python 3.11. When RENEE runs on Python 3.12, the import chain fails:

```
ccbr_tools/pkg_util.py (top-level import of cffconvert)
  → cffconvert → jsonschema → referencing._core
    → rpds (rpds.cpython-311-x86_64-linux-gnu.so)
      → ModuleNotFoundError: No module named 'rpds.rpds'
```

## Solution

ccbr_tools v0.5.3 includes a lazy-import fix (CCBR/Tools#182):
- Moved `cffconvert` imports from module level into the `print_citation()` function
- Defers the problematic import chain until the citation feature is explicitly used
- Allows RENEE to run on Python 3.12 without rpds errors

This is the same pattern as the PySimpleGUI fix in commit 82c32d1.

## Verification

- ✅ `renee --help` works on Python 3.12
- ✅ No rpds import errors
- ✅ Upstream fix verified in CCBR/Tools#182

## Related Issues

- Closes #282
- Related to CCBR/Tools#182